### PR TITLE
Use mkdirp instead of mkdir -p

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   ],
   "devDependencies": {
     "autoprefixer": "^7.1.2",
-    "babel-cli": "^6.24.1",
+    "babel-cli": "^6.26.0",
     "babel-plugin-add-module-exports": "^0.2.1",
     "babel-plugin-transform-class-properties": "^6.24.1",
     "babel-preset-es2015": "^6.24.1",


### PR DESCRIPTION
@ereplogle I started rewriting the shell scripts as node scripts, but if the only problem you were having was the `mkdir -p`, it started to seem like it was a fair amount more code to accomplish the same thing. Instead, this PR modifies the script to use the node module [mkdirp](https://www.npmjs.com/package/mkdirp), which should be windows-compatible.

I'll merge this now so that to try it out you can:

- pull the `master` branch of `react-plotly.js-editor`
- `npm install`
- `npm run prepublishOnly`