### PR TITLE
rename NumericInputStatefulWrapper resolves #102

### DIFF
--- a/src/components/containers/__tests__/Layout-test.js
+++ b/src/components/containers/__tests__/Layout-test.js
@@ -1,6 +1,6 @@
 import {Numeric} from '../../fields';
 import {Fold, Panel, Section} from '..';
-import NumericInput from '../../widgets/NumericInputStatefulWrapper';
+import NumericInput from '../../widgets/NumericInput';
 import React from 'react';
 import {EDITOR_ACTIONS} from '../../../lib/constants';
 import {TestEditor, fixtures} from '../../../lib/test-utils';

--- a/src/components/fields/Numeric.js
+++ b/src/components/fields/Numeric.js
@@ -1,5 +1,5 @@
 import Field from './Field';
-import NumericInput from '../widgets/NumericInputStatefulWrapper';
+import NumericInput from '../widgets/NumericInput';
 import PropTypes from 'prop-types';
 import React, {Component} from 'react';
 import {connectToContainer} from '../../lib';

--- a/src/components/widgets/NumericInput.js
+++ b/src/components/widgets/NumericInput.js
@@ -6,7 +6,7 @@ import isNumeric from 'fast-isnumeric';
 export const UP_ARROW = 38;
 export const DOWN_ARROW = 40;
 
-export default class NumericInputStatefulWrapper extends Component {
+export default class NumericInput extends Component {
   constructor(props) {
     super(props);
 
@@ -132,7 +132,7 @@ export default class NumericInputStatefulWrapper extends Component {
   }
 }
 
-NumericInputStatefulWrapper.propTypes = {
+NumericInput.propTypes = {
   defaultValue: PropTypes.number,
   editableClassName: PropTypes.string,
   integerOnly: PropTypes.bool,
@@ -145,6 +145,6 @@ NumericInputStatefulWrapper.propTypes = {
   value: PropTypes.any,
 };
 
-NumericInputStatefulWrapper.defaultProps = {
+NumericInput.defaultProps = {
   showArrows: true,
 };

--- a/src/lib/__tests__/connectLayoutToPlot-test.js
+++ b/src/lib/__tests__/connectLayoutToPlot-test.js
@@ -1,4 +1,4 @@
-import NumericInput from '../../components/widgets/NumericInputStatefulWrapper';
+import NumericInput from '../../components/widgets/NumericInput';
 import React from 'react';
 import connectLayoutToPlot from '../connectLayoutToPlot';
 import {EDITOR_ACTIONS} from '../constants';

--- a/src/lib/__tests__/connectTraceToPlot-test.js
+++ b/src/lib/__tests__/connectTraceToPlot-test.js
@@ -1,4 +1,4 @@
-import NumericInput from '../../components/widgets/NumericInputStatefulWrapper';
+import NumericInput from '../../components/widgets/NumericInput';
 import React from 'react';
 import connectTraceToPlot from '../connectTraceToPlot';
 import {EDITOR_ACTIONS} from '../constants';

--- a/src/lib/__tests__/multiValued-test.js
+++ b/src/lib/__tests__/multiValued-test.js
@@ -1,4 +1,4 @@
-import NumericInput from '../../components/widgets/NumericInputStatefulWrapper';
+import NumericInput from '../../components/widgets/NumericInput';
 import React from 'react';
 import {MULTI_VALUED_PLACEHOLDER} from '../constants';
 import {Numeric} from '../../components';

--- a/src/lib/__tests__/nestedContainerConnections-test.js
+++ b/src/lib/__tests__/nestedContainerConnections-test.js
@@ -1,4 +1,4 @@
-import NumericInput from '../../components/widgets/NumericInputStatefulWrapper';
+import NumericInput from '../../components/widgets/NumericInput';
 import React from 'react';
 import {EDITOR_ACTIONS} from '../constants';
 import {Numeric, Section, Panel} from '../../components';


### PR DESCRIPTION
Get rid of funky name that no longer even applies.

@nicolaskruchten @VeraZab another straightforward review