### PR TITLE
React.PropTypes is deprecated

### DIFF
--- a/src/components/fields/MultiFormatTextEditor.js
+++ b/src/components/fields/MultiFormatTextEditor.js
@@ -1,6 +1,7 @@
 import Field from './Field';
 import MultiFormatTextEditor from '../widgets/text_editors/MultiFormatTextEditor';
-import React, {Component, PropTypes} from 'react';
+import React, {Component} from 'react';
+import PropTypes from 'prop-types';
 import {connectToContainer} from '../../lib';
 
 export class UnconnectedMultiFormatTextEditor extends Component {

--- a/src/components/widgets/TextArea.js
+++ b/src/components/widgets/TextArea.js
@@ -1,4 +1,5 @@
 import React, {Component} from 'react';
+import PropTypes from 'prop-types';
 
 export default class TextArea extends Component {
   constructor(props) {
@@ -44,12 +45,12 @@ export default class TextArea extends Component {
 }
 
 TextArea.propTypes = {
-  value: React.PropTypes.string.isRequired,
-  onChange: React.PropTypes.func.isRequired,
-  placeholder: React.PropTypes.string.isRequired,
-  visibleRows: React.PropTypes.number,
-  areaWidth: React.PropTypes.number,
-  textareaClass: React.PropTypes.string,
+  value: PropTypes.string.isRequired,
+  onChange: PropTypes.func.isRequired,
+  placeholder: PropTypes.string.isRequired,
+  visibleRows: PropTypes.number,
+  areaWidth: PropTypes.number,
+  textareaClass: PropTypes.string,
 };
 
 TextArea.defaultProps = {

--- a/src/components/widgets/text_editors/LaTeX.js
+++ b/src/components/widgets/text_editors/LaTeX.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import TextArea from '../TextArea';
+import PropTypes from 'prop-types';
 
 import {isLaTeXExpr as isWrapped} from './convertFormats';
 
@@ -74,9 +75,9 @@ export default class LaTeX extends TextArea {
 }
 
 LaTeX.propTypes = {
-  onChange: React.PropTypes.func.isRequired,
-  value: React.PropTypes.string,
-  placeholder: React.PropTypes.string,
+  onChange: PropTypes.func.isRequired,
+  value: PropTypes.string,
+  placeholder: PropTypes.string,
 };
 
 LaTeX.defaultProps = {

--- a/src/components/widgets/text_editors/MultiFormatTextEditor.js
+++ b/src/components/widgets/text_editors/MultiFormatTextEditor.js
@@ -1,6 +1,7 @@
 import HTMLEditor from './HTML';
 import LaTeXEditor from './LaTeX';
-import React, {PropTypes, Component} from 'react';
+import React, {Component} from 'react';
+import PropTypes from 'prop-types';
 import RichTextEditor from './RichText';
 import localize from '../../../lib/localize';
 import {

--- a/src/components/widgets/text_editors/RichText/LinkDecorator.js
+++ b/src/components/widgets/text_editors/RichText/LinkDecorator.js
@@ -6,7 +6,8 @@
  * https://facebook.github.io/draft-js/docs/advanced-topics-decorators.html#decorator-components
  */
 
-import React, {PropTypes} from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import {Entity} from 'draft-js';
 
 const LinkDecorator = props => {

--- a/src/components/widgets/text_editors/RichText/LinkEditor.js
+++ b/src/components/widgets/text_editors/RichText/LinkEditor.js
@@ -3,7 +3,8 @@
  * in the RichTextEditor, and lets the user enter a URL.
  */
 
-import React, {Component, PropTypes} from 'react';
+import React, {Component} from 'react';
+import PropTypes from 'prop-types';
 import {RETURN_KEY, ESCAPE_KEY} from '../../../../lib/constants';
 import localize from '../../../../lib/localize';
 import {findDOMNode} from 'react-dom';

--- a/src/components/widgets/text_editors/RichText/StyleButton.js
+++ b/src/components/widgets/text_editors/RichText/StyleButton.js
@@ -1,7 +1,8 @@
-import React, {PropTypes} from 'react';
+import React, {Component} from 'react';
+import PropTypes from 'prop-types';
 import classnames from 'classnames';
 
-class StyleButton extends React.Component {
+class StyleButton extends Component {
   constructor(props) {
     super(props);
 

--- a/src/components/widgets/text_editors/RichText/StyleButtonGroup.js
+++ b/src/components/widgets/text_editors/RichText/StyleButtonGroup.js
@@ -1,4 +1,5 @@
-import React, {Component, PropTypes} from 'react';
+import React, {Component} from 'react';
+import PropTypes from 'prop-types';
 import StyleButton from './StyleButton';
 import {LINK} from './configuration';
 

--- a/src/components/widgets/text_editors/RichText/index.js
+++ b/src/components/widgets/text_editors/RichText/index.js
@@ -1,5 +1,5 @@
-import React, {Component, PropTypes} from 'react';
-
+import React, {Component} from 'react';
+import PropTypes from 'prop-types';
 import {
   CompositeDecorator,
   Editor,


### PR DESCRIPTION
I tried to get rid of this warning but didn't completely succeed. I suspect it's now coming from one of our dependencies.

![image](https://user-images.githubusercontent.com/203523/33491503-7f5b569a-d688-11e7-8b89-4b92d394190a.png)
