### PR TITLE
fold fixes: checking children of children

### DIFF
--- a/src/components/containers/__tests__/Fold-test.js
+++ b/src/components/containers/__tests__/Fold-test.js
@@ -1,5 +1,5 @@
 import {Numeric} from '../../fields';
-import {Fold, Panel} from '..';
+import {Fold, Panel, Info} from '..';
 import React from 'react';
 import {TestEditor, fixtures, mount} from 'lib/test-utils';
 import {connectTraceToPlot} from 'lib';
@@ -47,5 +47,19 @@ describe('<Fold>', () => {
 
     const payload = beforeDeleteTrace.mock.calls[0][0];
     expect(payload).toEqual({traceIndexes: [0]});
+  });
+
+  it('displays fold if it contains a child that has no attr', () => {
+    const wrapper = mount(
+      <TestEditor {...fixtures.scatter()}>
+        <Panel>
+          <Fold>
+            <div> ok </div>
+          </Fold>
+        </Panel>
+      </TestEditor>
+    );
+
+    expect(wrapper.find('.fold__content').length).toEqual(1);
   });
 });

--- a/src/components/containers/__tests__/Fold-test.js
+++ b/src/components/containers/__tests__/Fold-test.js
@@ -1,5 +1,5 @@
 import {Numeric} from '../../fields';
-import {Fold, Panel, Info} from '..';
+import {Fold, Panel} from '..';
 import React from 'react';
 import {TestEditor, fixtures, mount} from 'lib/test-utils';
 import {connectTraceToPlot} from 'lib';


### PR DESCRIPTION
previous pr wasn't complete because I wasn't checking if a child contained folds, just if the immediate child was a fold.

There's still some weirdness, but that's related to plotProps.visible somehow being true for attributes I wouldn't expect it to (below: plotProps for 'ticks' and 'labels' somehow show isVisible = true)
![screen shot 2018-03-08 at 2 42 15 pm](https://user-images.githubusercontent.com/4257572/37172604-4ea33222-22df-11e8-8dc3-3c741381df84.png)

Not ideal, but not the end of the world if we need something immediately merged and released.

@nicolaskruchten would you take a look?