### PR TITLE
node-sass: workaround missing vendor folder

### DIFF
--- a/package.json
+++ b/package.json
@@ -108,6 +108,7 @@
     "make:lib:css": "mkdirp lib && babel-node scripts/styles.js && SASS_ENV=ie babel-node scripts/styles.js && babel-node scripts/postcss.js && SASS_ENV=ie babel-node scripts/postcss.js",
     "make:lib:js": "mkdirp lib && babel src --out-dir lib --ignore=__tests__/* --source-maps",
     "make:translation-keys": "node scripts/findTranslationKeys.js",
+    "postinstall": "npm rebuild node-sass",
     "prepublishOnly": "npm run make:lib",
     "start": "webpack-dev-server --hot",
     "test": "npm run test:lint && npm run test:pretty && npm run test:js",


### PR DESCRIPTION
After a fresh install:
```
git clone https://github.com/plotly/react-chart-editor.git
cd react-chart-editor
npm install
```

running `npm run make:lib:css` fails because of  issue https://github.com/sass/node-sass/issues/1579.

This PR adds a postinstall script to rebuild `node-sass` and fix this issue.