### PR TITLE
enable toggling the editor display

### DIFF
--- a/src/EditorControls.js
+++ b/src/EditorControls.js
@@ -22,9 +22,6 @@ class EditorControls extends Component {
       this.plotSchema = this.props.plotly.PlotSchema.get();
     }
 
-    this.state = {
-      visible: this.props.visible
-    }
   }
 
   getChildContext() {
@@ -254,7 +251,7 @@ class EditorControls extends Component {
           ' plotly-editor--theme-provider' +
           `${this.props.className ? ` ${this.props.className}` : ''}`
         }
-        style={{display: this.state.visible ? 'unset': 'none'}}
+        style={{display: (this.props.visible === undefined || this.props.visible) ? 'unset': 'none'}}
       >
         <ModalProvider>
           {this.props.graphDiv &&

--- a/src/EditorControls.js
+++ b/src/EditorControls.js
@@ -21,6 +21,10 @@ class EditorControls extends Component {
     if (this.props.plotly) {
       this.plotSchema = this.props.plotly.PlotSchema.get();
     }
+
+    this.state = {
+      visible: this.props.visible
+    }
   }
 
   getChildContext() {
@@ -250,6 +254,7 @@ class EditorControls extends Component {
           ' plotly-editor--theme-provider' +
           `${this.props.className ? ` ${this.props.className}` : ''}`
         }
+        style={{display: this.state.visible ? 'unset': 'none'}}
       >
         <ModalProvider>
           {this.props.graphDiv &&

--- a/src/EditorControls.js
+++ b/src/EditorControls.js
@@ -250,7 +250,6 @@ class EditorControls extends Component {
           ' plotly-editor--theme-provider' +
           `${this.props.className ? ` ${this.props.className}` : ''}`
         }
-        style={{display: (this.props.visible === undefined || this.props.visible) ? 'unset': 'none'}}
       >
         <ModalProvider>
           {this.props.graphDiv &&

--- a/src/EditorControls.js
+++ b/src/EditorControls.js
@@ -21,7 +21,6 @@ class EditorControls extends Component {
     if (this.props.plotly) {
       this.plotSchema = this.props.plotly.PlotSchema.get();
     }
-
   }
 
   getChildContext() {

--- a/src/PlotlyEditor.js
+++ b/src/PlotlyEditor.js
@@ -5,7 +5,7 @@ import PropTypes from 'prop-types';
 
 class PlotlyEditor extends Component {
   constructor(props) {
-    super(props);
+    super();
     this.state = {graphDiv: {}};
     this.PlotComponent = createPlotComponent(props.plotly);
   }

--- a/src/PlotlyEditor.js
+++ b/src/PlotlyEditor.js
@@ -13,20 +13,21 @@ class PlotlyEditor extends Component {
   render() {
     return (
       <div className="plotly_editor">
-        <EditorControls
-          graphDiv={this.state.graphDiv}
-          dataSources={this.props.dataSources}
-          dataSourceOptions={this.props.dataSourceOptions}
-          plotly={this.props.plotly}
-          onUpdate={this.props.onUpdate}
-          advancedTraceTypeSelector={this.props.advancedTraceTypeSelector}
-          locale={this.props.locale}
-          traceTypesConfig={this.props.traceTypesConfig}
-          dictionaries={this.props.dictionaries}
-          visible={this.props.controlsVisible}
-        >
-          {this.props.children}
-        </EditorControls>
+        {(this.props.controlsVisible === undefined || this.props.controlsVisible) &&
+          <EditorControls
+            graphDiv={this.state.graphDiv}
+            dataSources={this.props.dataSources}
+            dataSourceOptions={this.props.dataSourceOptions}
+            plotly={this.props.plotly}
+            onUpdate={this.props.onUpdate}
+            advancedTraceTypeSelector={this.props.advancedTraceTypeSelector}
+            locale={this.props.locale}
+            traceTypesConfig={this.props.traceTypesConfig}
+            dictionaries={this.props.dictionaries}
+          >
+            {this.props.children}
+          </EditorControls>
+        }
         <div
           className="plotly_editor_plot"
           style={{width: '100%', height: '100%'}}

--- a/src/PlotlyEditor.js
+++ b/src/PlotlyEditor.js
@@ -13,7 +13,7 @@ class PlotlyEditor extends Component {
   render() {
     return (
       <div className="plotly_editor">
-        {(this.props.controlsVisible === undefined || this.props.controlsVisible) &&
+        {!this.props.hideControls &&
           <EditorControls
             graphDiv={this.state.graphDiv}
             dataSources={this.props.dataSources}
@@ -67,6 +67,11 @@ PlotlyEditor.propTypes = {
   traceTypesConfig: PropTypes.object,
   dictionaries: PropTypes.object,
   divId: PropTypes.string,
+  hideControls: PropTypes.bool,
+};
+
+PlotlyEditor.defaultProps = {
+  hideControls: false,
 };
 
 export default PlotlyEditor;

--- a/src/PlotlyEditor.js
+++ b/src/PlotlyEditor.js
@@ -5,11 +5,8 @@ import PropTypes from 'prop-types';
 
 class PlotlyEditor extends Component {
   constructor(props) {
-    super();
-    this.state = {
-      graphDiv: {},
-      editorControlsVisible: true
-    };
+    super(props);
+    this.state = {graphDiv: {}};
     this.PlotComponent = createPlotComponent(props.plotly);
   }
 
@@ -26,7 +23,7 @@ class PlotlyEditor extends Component {
           locale={this.props.locale}
           traceTypesConfig={this.props.traceTypesConfig}
           dictionaries={this.props.dictionaries}
-          visible={this.state.editorControlsVisible}
+          visible={this.props.controlsVisible}
         >
           {this.props.children}
         </EditorControls>

--- a/src/PlotlyEditor.js
+++ b/src/PlotlyEditor.js
@@ -6,7 +6,10 @@ import PropTypes from 'prop-types';
 class PlotlyEditor extends Component {
   constructor(props) {
     super();
-    this.state = {graphDiv: {}};
+    this.state = {
+      graphDiv: {},
+      editorControlsVisible: true
+    };
     this.PlotComponent = createPlotComponent(props.plotly);
   }
 
@@ -23,6 +26,7 @@ class PlotlyEditor extends Component {
           locale={this.props.locale}
           traceTypesConfig={this.props.traceTypesConfig}
           dictionaries={this.props.dictionaries}
+          visible={this.state.editorControlsVisible}
         >
           {this.props.children}
         </EditorControls>

--- a/src/PlotlyEditor.js
+++ b/src/PlotlyEditor.js
@@ -13,7 +13,7 @@ class PlotlyEditor extends Component {
   render() {
     return (
       <div className="plotly_editor">
-        {!this.props.hideControls &&
+        {!this.props.hideControls && (
           <EditorControls
             graphDiv={this.state.graphDiv}
             dataSources={this.props.dataSources}
@@ -27,7 +27,7 @@ class PlotlyEditor extends Component {
           >
             {this.props.children}
           </EditorControls>
-        }
+        )}
         <div
           className="plotly_editor_plot"
           style={{width: '100%', height: '100%'}}


### PR DESCRIPTION
This adds a `visible` prop to `<EditorControls/>`, and a `controlsVisible` prop to `<PlotlyEditor/>`.  The default if those props are not provided is the current behavior of displaying the editor.  If the parent  passes a value `false` in that prop, the controls are hidden but still exist in the DOM.  This enables the option to toggle the controls on and off from a parent component.  Thanks for your consideration @nicolaskruchten. 

Resolves #448 