### PR TITLE
clean up trace selector

### DIFF
--- a/src/components/widgets/TraceTypeSelector.js
+++ b/src/components/widgets/TraceTypeSelector.js
@@ -122,8 +122,9 @@ class TraceTypeSelector extends Component {
   }
 
   render() {
+    const {localize: _} = this.context;
     return (
-      <Modal title="Select Chart Type">
+      <Modal title={_('Select Trace Type')}>
         <div className="trace-grid">{this.renderCategories()}</div>
       </Modal>
     );

--- a/src/lib/traceTypes.js
+++ b/src/lib/traceTypes.js
@@ -40,9 +40,9 @@ export const categoryLayout = _ => [
   chartCategory(_).SIMPLE,
   chartCategory(_).WEB_GL,
   chartCategory(_).DISTRIBUTIONS,
-  chartCategory(_).FINANCIAL,
-  chartCategory(_).MAPS,
   chartCategory(_).SPECIALIZED,
+  chartCategory(_).MAPS,
+  chartCategory(_).FINANCIAL,
 ];
 
 export const traceTypes = _ => [
@@ -195,13 +195,13 @@ export const traceTypes = _ => [
   {
     value: 'scatterpolargl',
     icon: 'scatterpolar',
-    label: _('Scatter Polar GL'),
+    label: _('Polar Scatter GL'),
     category: chartCategory(_).WEB_GL,
   },
-  {
-    value: 'heatmapgl',
-    icon: 'heatmap',
-    label: _('Heatmap GL'),
-    category: chartCategory(_).WEB_GL,
-  },
+  // {
+  //   value: 'heatmapgl',
+  //   icon: 'heatmap',
+  //   label: _('Heatmap GL'),
+  //   category: chartCategory(_).WEB_GL,
+  // },
 ];


### PR DESCRIPTION
* Localize and rename modal to say Trace instead of Chart
* Remove HeatmapGL as per plotly.js team update
* Standardize scatter polar labelling
* Moving Specialized left so as to make it clearer that the Polar Scatter GL is an optimized version of Polar (i.e. the "X GL" are all to the right of the corresponding "X")