### PR TITLE
Remove key and keysrc when no dataSources

### DIFF
--- a/src/lib/dereference.js
+++ b/src/lib/dereference.js
@@ -2,7 +2,7 @@ import walkObject from './walkObject';
 
 const SRC_ATTR_PATTERN = /src$/;
 
-export default function dereference(container, dataSources) {
+export default function dereference(container, dataSources, deleteKeys) {
   const replacer = (key, parent) => {
     if (!SRC_ATTR_PATTERN.test(key)) {
       return;
@@ -12,12 +12,12 @@ export default function dereference(container, dataSources) {
     const data = dataSources[srcRef];
     const dataKey = key.replace(SRC_ATTR_PATTERN, '');
 
-    if (!Array.isArray(data)) {
-      if (Object.keys(dataSources).length === 0) {
-        delete parent[dataKey];
-        delete parent[key];
-      }
+    if (deleteKeys && !(srcRef in dataSources)) {
+      delete parent[dataKey];
+      return;
+    }
 
+    if (!Array.isArray(data)) {
       return;
     }
 

--- a/src/lib/dereference.js
+++ b/src/lib/dereference.js
@@ -2,7 +2,11 @@ import walkObject from './walkObject';
 
 const SRC_ATTR_PATTERN = /src$/;
 
-export default function dereference(container, dataSources, config = {deleteKeys: false}) {
+export default function dereference(
+  container,
+  dataSources,
+  config = {deleteKeys: false}
+) {
   const replacer = (key, parent) => {
     if (!SRC_ATTR_PATTERN.test(key)) {
       return;

--- a/src/lib/dereference.js
+++ b/src/lib/dereference.js
@@ -10,12 +10,17 @@ export default function dereference(container, dataSources) {
 
     const srcRef = parent[key];
     const data = dataSources[srcRef];
+    const dataKey = key.replace(SRC_ATTR_PATTERN, '');
 
     if (!Array.isArray(data)) {
+      if (Object.keys(dataSources).length === 0) {
+        delete parent[dataKey];
+        delete parent[key];
+      }
+
       return;
     }
 
-    const dataKey = key.replace(SRC_ATTR_PATTERN, '');
     parent[dataKey] = data;
   };
 

--- a/src/lib/dereference.js
+++ b/src/lib/dereference.js
@@ -2,7 +2,7 @@ import walkObject from './walkObject';
 
 const SRC_ATTR_PATTERN = /src$/;
 
-export default function dereference(container, dataSources, deleteKeys) {
+export default function dereference(container, dataSources, config = {deleteKeys: false}) {
   const replacer = (key, parent) => {
     if (!SRC_ATTR_PATTERN.test(key)) {
       return;
@@ -12,7 +12,7 @@ export default function dereference(container, dataSources, deleteKeys) {
     const data = dataSources[srcRef];
     const dataKey = key.replace(SRC_ATTR_PATTERN, '');
 
-    if (deleteKeys && !(srcRef in dataSources)) {
+    if (config.deleteKeys && !(srcRef in dataSources)) {
       delete parent[dataKey];
       return;
     }


### PR DESCRIPTION
@bpostlethwaite would you 💃 ?
This adjusts the dereferencing function so as to remove the parent[key] and parent[keysrc] from dereferenced object, if dataSources is an empty object.

It fixes the case in streambed where the plot keeps its data, even if the column referenced in it has been removed.