### PR TITLE
Detached DataSelector

### DIFF
--- a/dev/App.js
+++ b/dev/App.js
@@ -12,7 +12,7 @@ import 'brace/mode/json';
 import 'brace/theme/textmate';
 
 // https://github.com/plotly/react-chart-editor#mapbox-access-tokens
-import ACCESS_TOKENS from '../accessTokens';
+//import ACCESS_TOKENS from '../accessTokens';
 
 const dataSources = {
   ints: [1, 2, 3, 4, 5, 6], // eslint-disable-line no-magic-numbers
@@ -36,7 +36,7 @@ const dataSourceOptions = Object.keys(dataSources).map(name => ({
   label: name,
 }));
 
-const config = {mapboxAccessToken: ACCESS_TOKENS.MAPBOX, editable: true};
+const config = {/*mapboxAccessToken: ACCESS_TOKENS.MAPBOX,*/ editable: true};
 
 class App extends Component {
   constructor() {

--- a/dev/App.js
+++ b/dev/App.js
@@ -6,13 +6,13 @@ import 'react-select/dist/react-select.css';
 import brace from 'brace'; // eslint-disable-line no-unused-vars
 import AceEditor from 'react-ace';
 import Select from 'react-select';
-import PlotlyEditor, {DefaultEditor, Panel, DetachedDataSelector} from '../src';
+import PlotlyEditor, {DefaultEditor, Panel} from '../src';
 import Inspector from 'react-inspector';
 import 'brace/mode/json';
 import 'brace/theme/textmate';
 
 // https://github.com/plotly/react-chart-editor#mapbox-access-tokens
-//import ACCESS_TOKENS from '../accessTokens';
+import ACCESS_TOKENS from '../accessTokens';
 
 const dataSources = {
   ints: [1, 2, 3, 4, 5, 6], // eslint-disable-line no-magic-numbers
@@ -36,7 +36,7 @@ const dataSourceOptions = Object.keys(dataSources).map(name => ({
   label: name,
 }));
 
-const config = {/*mapboxAccessToken: ACCESS_TOKENS.MAPBOX,*/ editable: true};
+const config = {mapboxAccessToken: ACCESS_TOKENS.MAPBOX, editable: true};
 
 class App extends Component {
   constructor() {
@@ -100,25 +100,7 @@ class App extends Component {
     }
   }
 
-
-  myOnChange(value){
-    console.log(value);
-  }
-
   render() {
-
-    let myDataSources = {
-      option_one: 1,
-      option_two: 2,
-      option_three: 3,
-      option_four: 4,
-    };
-    const myDataSourceOptions = Object.keys(myDataSources).map(name => ({
-      value: name,
-      label: name,
-    }));
-
-
     return (
       <div className="app">
         <PlotlyEditor
@@ -137,14 +119,6 @@ class App extends Component {
           showFieldTooltips
         >
           <DefaultEditor>
-          <Panel group="Dev" name="Test">
-            <DetachedDataSelector
-                  options={myDataSourceOptions}
-                  value={{ value: 'one', label: 'One' }}
-                  onChange={this.myOnChange}
-                  multi={false}
-            />
-          </Panel>
             <Panel group="Dev" name="JSON">
               <div className="mocks">
                 <Select

--- a/dev/App.js
+++ b/dev/App.js
@@ -6,7 +6,7 @@ import 'react-select/dist/react-select.css';
 import brace from 'brace'; // eslint-disable-line no-unused-vars
 import AceEditor from 'react-ace';
 import Select from 'react-select';
-import PlotlyEditor, {DefaultEditor, Panel} from '../src';
+import PlotlyEditor, {DefaultEditor, Panel, DetachedDataSelector} from '../src';
 import Inspector from 'react-inspector';
 import 'brace/mode/json';
 import 'brace/theme/textmate';
@@ -100,7 +100,25 @@ class App extends Component {
     }
   }
 
+
+  myOnChange(value){
+    console.log(value);
+  }
+
   render() {
+
+    let myDataSources = {
+      option_one: 1,
+      option_two: 2,
+      option_three: 3,
+      option_four: 4,
+    };
+    const myDataSourceOptions = Object.keys(myDataSources).map(name => ({
+      value: name,
+      label: name,
+    }));
+
+
     return (
       <div className="app">
         <PlotlyEditor
@@ -119,6 +137,14 @@ class App extends Component {
           showFieldTooltips
         >
           <DefaultEditor>
+          <Panel group="Dev" name="Test">
+            <DetachedDataSelector
+                  options={myDataSourceOptions}
+                  value={{ value: 'one', label: 'One' }}
+                  onChange={this.myOnChange}
+                  multi={false}
+            />
+          </Panel>
             <Panel group="Dev" name="JSON">
               <div className="mocks">
                 <Select

--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
     "babel-preset-react": "^6.24.1",
     "babel-preset-stage-2": "^6.24.1",
     "babel-traverse": "^6.26.0",
-    "canvas": "^1.6.9",
     "css-loader": "^0.28.9",
     "cssnano": "^3.10.0",
     "enzyme": "^3.1.0",

--- a/src/components/detached_fields/DetachedDataSelector.js
+++ b/src/components/detached_fields/DetachedDataSelector.js
@@ -16,7 +16,7 @@ export class DetachedDataSelector extends Component {
           value={this.props.value}
           onChange={this.props.onChange}
           multi={this.props.multi}
-          clearable={true}
+          clearable={this.props.clearable}
         />
       </Field>
     );
@@ -27,7 +27,8 @@ DetachedDataSelector.defaultProps = {
   options: null,
   value: '',
   onChange: null,
-  multi: false
+  multi: false,
+  clearable: true
 };
 
 

--- a/src/components/detached_fields/DetachedDataSelector.js
+++ b/src/components/detached_fields/DetachedDataSelector.js
@@ -1,0 +1,34 @@
+import DropdownWidget from '../widgets/Dropdown';
+import React, {Component} from 'react';
+import Field from './Field';
+
+export class DetachedDataSelector extends Component {
+  constructor(props, context) {
+    super(props, context);
+  }
+
+
+  render() {
+    return (
+      <Field>
+        <DropdownWidget
+          options={this.props.options}
+          value={this.props.value}
+          onChange={this.props.onChange}
+          multi={this.props.multi}
+          clearable={true}
+        />
+      </Field>
+    );
+  }
+}
+
+DetachedDataSelector.defaultProps = {
+  options: null,
+  value: '',
+  onChange: null,
+  multi: false
+};
+
+
+export default DetachedDataSelector;

--- a/src/components/detached_fields/Field.js
+++ b/src/components/detached_fields/Field.js
@@ -1,0 +1,116 @@
+import PropTypes from 'prop-types';
+import React, {Component} from 'react';
+import MenuPanel from '../containers/MenuPanel';
+import classnames from 'classnames';
+import {bem} from 'lib';
+import {getMultiValueText} from 'lib/constants';
+import {CloseIcon} from 'plotly-icons';
+
+export class FieldDelete extends Component {
+  render() {
+    const {onClick} = this.props;
+    return (
+      <div className="field__delete" onClick={onClick}>
+        <CloseIcon />
+      </div>
+    );
+  }
+}
+
+class Field extends Component {
+  render() {
+    const {
+      center,
+      children,
+      label,
+      multiValued,
+      units,
+      extraComponent,
+    } = this.props;
+
+    const {localize: _} = this.context;
+
+    let fieldClass;
+    if (!label) {
+      fieldClass = classnames('field__no-title', {
+        'field__no-title--center': center,
+      });
+    } else {
+      fieldClass = classnames('field__widget', {
+        'field__widget--units': Boolean(units),
+      });
+    }
+
+    let tooltip = this.context.attr;
+    if (this.context.description) {
+      tooltip +=
+        ' – ' + this.context.description.replace(/`/g, '"').replace(/\*/g, '"');
+    }
+
+    return (
+      <div className={bem('field')}>
+        {label ? (
+          <div className={bem('field', 'title')}>
+            {this.context.showFieldTooltips ? (
+              <div
+                className={bem('field', 'title-text')}
+                aria-label={tooltip}
+                data-microtip-position="bottom-right"
+                data-microtip-size="large"
+                role="tooltip"
+              >
+                {label}
+              </div>
+            ) : (
+              <div className={bem('field', 'title-text')}>{label}</div>
+            )}
+          </div>
+        ) : null}
+        <div className={fieldClass}>
+          {children}
+          {multiValued ? (
+            <MenuPanel label={getMultiValueText('title', _)} ownline question>
+              <div className="info__title">{getMultiValueText('title', _)}</div>
+              <div className="info__text">{getMultiValueText('text', _)}</div>
+              <div className="info__sub-text">
+                {getMultiValueText('subText', _)}
+              </div>
+            </MenuPanel>
+          ) : null}
+          {extraComponent ? extraComponent : null}
+        </div>
+        {units ? (
+          <div className={bem('field', 'units')}>
+            <div className={bem('field', 'units-text')}>{units}</div>
+          </div>
+        ) : null}
+      </div>
+    );
+  }
+}
+
+Field.propTypes = {
+  center: PropTypes.bool,
+  label: PropTypes.any,
+  units: PropTypes.string,
+  multiValued: PropTypes.bool,
+  children: PropTypes.node,
+  extraComponent: PropTypes.any,
+};
+
+Field.contextTypes = {
+  localize: PropTypes.func,
+  description: PropTypes.string,
+  attr: PropTypes.string,
+  showFieldTooltips: PropTypes.bool,
+};
+
+Field.defaultProps = {
+  center: false,
+  multiValued: false,
+};
+
+FieldDelete.propTypes = {
+  onClick: PropTypes.func,
+};
+export default Field;

--- a/src/components/detached_fields/index.js
+++ b/src/components/detached_fields/index.js
@@ -1,0 +1,5 @@
+import DetachedDataSelector from './DetachedDataSelector';
+
+export {
+  DetachedDataSelector
+};

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -1,4 +1,8 @@
 import {
+  DetachedDataSelector,
+} from './detached_fields';
+
+import {
   AnnotationArrowRef,
   AnnotationRef,
   AxisAnchorDropdown,
@@ -137,4 +141,5 @@ export {
   UpdateMenuButtons,
   Dropzone,
   TextPosition,
+  DetachedDataSelector,
 };

--- a/src/index.js
+++ b/src/index.js
@@ -72,6 +72,7 @@ import {
   TraceMarkerSection,
   TraceRequiredPanel,
   TraceSelector,
+  DetachedDataSelector,
 } from './components';
 
 import {
@@ -167,6 +168,7 @@ export {
   walkObject,
   EditorControls,
   DefaultEditor,
+  DetachedDataSelector,
 };
 
 export default PlotlyEditor;


### PR DESCRIPTION
Hey Plotly,

I have added a detached_fields folder. This folder can contain fields that are 'detached' or do not affect the chart. I added a DetachedDataSelector, which is a dropdown that has the same style as the usual dropdown, except it does not affect the graph.

Thank you. As discussed with @nicolaskruchten, it would be greatly appreciated if this can be contributed and re-released quickly.