### PR TITLE
remove canvas devdep

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
     "babel-preset-react": "^6.24.1",
     "babel-preset-stage-2": "^6.24.1",
     "babel-traverse": "^6.26.0",
-    "canvas": "^1.6.9",
     "css-loader": "^0.28.9",
     "cssnano": "^3.10.0",
     "enzyme": "^3.1.0",


### PR DESCRIPTION
closes #467

removing this doesn't even seem to bring back any warnings, so maybe it wasn't needed after all