### PR TITLE
add fields in multiple traces, bugfixes, percy tests

### DIFF
--- a/dev/mocks.json
+++ b/dev/mocks.json
@@ -5,6 +5,7 @@
   "/percy/box.json",
   "/percy/histogram.json",
   "/percy/histogram2d.json",
+  "/percy/pie.json",
   "/percy/violin.json",
   "0.json",
   "1.json",

--- a/dev/percy/index.js
+++ b/dev/percy/index.js
@@ -1,8 +1,9 @@
 import panelTest from './panelTest.json';
 import histogram from './histogram.json';
 import histogram2d from './histogram2d.json';
+import pie from './pie.json';
 import violin from './violin.json';
 import bar from './bar.json';
 import box from './box.json';
 
-export {panelTest, histogram, histogram2d, violin, bar, box};
+export {panelTest, histogram, histogram2d, pie, violin, bar, box};

--- a/dev/percy/panelTest.json
+++ b/dev/percy/panelTest.json
@@ -36,14 +36,11 @@
         "color": [
           1,
           2,
-          3,
-          4,
-          5,
-          6
+          3
         ],
-        "colorsrc": "ints",
+        "colorsrc": "x1",
         "cmin": 1,
-        "cmax": 6,
+        "cmax": 3,
         "cauto": true,
         "colorscale": [
           [
@@ -67,8 +64,24 @@
         "showscale": true,
         "colorbar": {
           "ticks": "inside"
-        }
-      }
+        },
+        "size": [
+          1,
+          2,
+          3
+        ],
+        "sizesrc": "x1",
+        "sizemode": "diameter"
+      },
+      "fill": "tozerox",
+      "mode": "lines+markers+text",
+      "line": {
+        "dash": "solid",
+        "shape": "spline",
+        "color": "rgb(31, 119, 180)"
+      },
+      "hoveron": "fills+points",
+      "uid": "3102ee"
     },
     {
       "x": [
@@ -106,7 +119,7 @@
       "transforms": [
         {
           "type": "groupby",
-          "groupssrc": "ints",
+          "groupssrc": "x1",
           "groups": [],
           "enabled": true
         },
@@ -114,14 +127,26 @@
           "enabled": true,
           "type": "filter",
           "target": "x",
-          "targetsrc": "ints",
+          "targetsrc": "x1",
           "operation": "[]",
           "value": [
             "0",
             "1"
           ]
         }
-      ]
+      ],
+      "fill": "tozerox",
+      "mode": "lines+markers+text",
+      "marker": {
+        "sizemode": "diameter"
+      },
+      "line": {
+        "dash": "solid",
+        "shape": "spline",
+        "color": "rgb(31, 119, 180)"
+      },
+      "hoveron": "fills+points",
+      "uid": "f4d7ad"
     }
   ],
   "layout": {
@@ -135,7 +160,13 @@
         "color": "rgb(148, 103, 189)"
       },
       "overlaying": "y",
-      "side": "right"
+      "side": "right",
+      "type": "linear",
+      "range": [
+        17.77777777777778,
+        22.22222222222222
+      ],
+      "autorange": true
     },
     "annotations": [
       {
@@ -148,8 +179,8 @@
     "xaxis": {
       "type": "date",
       "range": [
-        0.6919103739269605,
-        6.3080896260730395
+        "1969-12-31 19:00:00.001",
+        "1969-12-31 19:00:00.0011"
       ],
       "autorange": true,
       "showline": true,
@@ -163,9 +194,12 @@
         },
         "autorange": true,
         "range": [
-          0.6919103739269605,
-          6.3080896260730395
-        ]
+          "1969-12-31 19:00:00.001",
+          "1969-12-31 19:00:00.0011"
+        ],
+        "yaxis2": {
+          "rangemode": "match"
+        }
       },
       "rangeselector": {
         "visible": true,
@@ -184,10 +218,11 @@
     },
     "yaxis": {
       "range": [
-        -0.32971827474445276,
-        5.329718274744453
+        1.9863013698630136,
+        4.013698630136986
       ],
-      "autorange": true
+      "autorange": true,
+      "type": "linear"
     },
     "autosize": true,
     "shapes": [
@@ -285,5 +320,6 @@
         "active": 1
       }
     ]
-  }
+  },
+  "frames": []
 }

--- a/dev/percy/pie.json
+++ b/dev/percy/pie.json
@@ -1,0 +1,47 @@
+{
+  "data": [
+    {
+      "type": "pie",
+      "mode": "markers",
+      "uid": "3e343a",
+      "labels": [
+        1,
+        2,
+        3
+      ],
+      "labelssrc": "x1",
+      "values": [
+        1,
+        2,
+        3
+      ],
+      "valuessrc": "x1",
+      "text": [
+        1,
+        2,
+        3
+      ],
+      "textsrc": "x1"
+    }
+  ],
+  "layout": {
+    "xaxis": {
+      "range": [
+        0.5699530516431925,
+        6.917370892018779
+      ],
+      "autorange": true,
+      "type": "linear"
+    },
+    "yaxis": {
+      "range": [
+        -0.3055555555555556,
+        5.805555555555555
+      ],
+      "autorange": true
+    },
+    "autosize": true,
+    "hovermode": "closest"
+  },
+  "frames": []
+}

--- a/src/__percy__/panels.percy.js
+++ b/src/__percy__/panels.percy.js
@@ -16,6 +16,7 @@ import './percy.css';
 const panelsToTest = {
   bar: ['GraphCreatePanel', 'StyleTracesPanel'],
   box: ['GraphCreatePanel', 'StyleTracesPanel'],
+  pie: ['GraphCreatePanel', 'StyleTracesPanel'],
   histogram: ['GraphCreatePanel', 'StyleTracesPanel'],
   histogram2d: ['GraphCreatePanel', 'StyleTracesPanel'],
   violin: ['GraphCreatePanel', 'StyleTracesPanel'],

--- a/src/components/fields/MarkerSize.js
+++ b/src/components/fields/MarkerSize.js
@@ -1,0 +1,93 @@
+import Field from './Field';
+import PropTypes from 'prop-types';
+import React, {Component} from 'react';
+import {connectToContainer} from 'lib';
+import RadioBlocks from '../widgets/RadioBlocks';
+import Numeric from './Numeric';
+import DataSelector from './DataSelector';
+
+const getType = value => (Array.isArray(value) ? 'variable' : 'constant');
+
+class UnconnectedMarkerSize extends Component {
+  constructor(props, context) {
+    super(props, context);
+
+    const type = getType(props.fullValue);
+    this.state = {
+      type,
+      value: {
+        constant: type === 'constant' ? props.fullValue : '6',
+        variable: type === 'variable' ? props.fullValue : null,
+      },
+    };
+
+    this.setType = this.setType.bind(this);
+    this.setValue = this.setValue.bind(this);
+  }
+
+  setType(type) {
+    this.setState({type: type});
+    this.props.updatePlot(this.state.value[type]);
+    if (type === 'constant') {
+      this.context.updateContainer({['marker.sizesrc']: null});
+    }
+  }
+
+  setValue(inputValue) {
+    const {type} = this.state;
+
+    this.setState(
+      type === 'constant'
+        ? {value: {constant: inputValue}}
+        : {value: {variable: inputValue}}
+    );
+    this.props.updatePlot(inputValue);
+  }
+
+  render() {
+    const {attr} = this.props;
+    const {localize: _} = this.context;
+    const options = [
+      {label: _('Constant'), value: 'constant'},
+      {label: _('Variable'), value: 'variable'},
+    ];
+
+    return (
+      <div>
+        <Field {...this.props} attr={attr}>
+          <RadioBlocks
+            options={options}
+            activeOption={this.state.type}
+            onOptionChange={this.setType}
+          />
+          {this.state.type === 'constant' ? (
+            <Numeric
+              attr="marker.size"
+              updatePlot={this.setValue}
+              fullValue={this.state.value.constant}
+            />
+          ) : (
+            <DataSelector
+              attr="marker.size"
+              updatePlot={this.setValue}
+              fullValue={this.state.value.variable}
+            />
+          )}
+        </Field>
+      </div>
+    );
+  }
+}
+
+UnconnectedMarkerSize.propTypes = {
+  fullValue: PropTypes.any,
+  updatePlot: PropTypes.func,
+  ...Field.propTypes,
+};
+
+UnconnectedMarkerSize.contextTypes = {
+  localize: PropTypes.func,
+  updateContainer: PropTypes.func,
+};
+
+export default connectToContainer(UnconnectedMarkerSize);

--- a/src/components/fields/derived.js
+++ b/src/components/fields/derived.js
@@ -308,6 +308,26 @@ export const NumericFractionInverse = connectToContainer(
   }
 );
 
+export const NumericReciprocal = connectToContainer(UnconnectedNumeric, {
+  modifyPlotProps: (props, context, plotProps) => {
+    const {fullValue, updatePlot} = plotProps;
+
+    if (isNumeric(fullValue)) {
+      plotProps.fullValue = Math.round(1 / fullValue);
+    }
+
+    plotProps.updatePlot = v => {
+      if (isNumeric(v)) {
+        updatePlot(1 / v);
+      } else {
+        updatePlot(v);
+      }
+    };
+
+    plotProps.min = 1;
+  },
+});
+
 export const AnnotationArrowRef = connectToContainer(UnconnectedDropdown, {
   modifyPlotProps: (props, context, plotProps) => {
     if (!context.fullContainer) {
@@ -489,6 +509,10 @@ export const HoverInfo = connectToContainer(UnconnectedFlaglist, {
       {label: _('Y'), value: 'y'},
       {label: _('Name'), value: 'name'},
     ];
+
+    if (context.container.text && context.container.text.length > 0) {
+      options.push({label: _('Text'), value: 'text'});
+    }
 
     if (
       [

--- a/src/components/fields/index.js
+++ b/src/components/fields/index.js
@@ -19,6 +19,7 @@ import ErrorBars from './ErrorBars';
 import AxisCreator from './AxisCreator';
 import UpdateMenuButtons from './UpdateMenuButtons';
 import {FilterOperation, FilterValue} from './FilterOperation';
+import MarkerSize from './MarkerSize';
 import {
   AnnotationArrowRef,
   AnnotationRef,
@@ -88,4 +89,5 @@ export {
   UpdateMenuButtons,
   Dropzone,
   TextPosition,
+  MarkerSize,
 };

--- a/src/components/fields/lineSelectors.js
+++ b/src/components/fields/lineSelectors.js
@@ -35,7 +35,10 @@ const strokeShapes = [
 ];
 
 const strokeStyle = {fill: 'none', strokeWidth: '4px'};
-const computeOptions = (strokeData, stroke) =>
+
+const mutedBlue = '#1f77b4';
+
+const computeOptions = (strokeData, stroke = mutedBlue) =>
   strokeData.map(({value, strokeDasharray, d = 'M0,8h100'}) => ({
     label: <path d={d} style={{...strokeStyle, stroke, strokeDasharray}} />,
     value,

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -43,6 +43,7 @@ import {
   UpdateMenuButtons,
   Dropzone,
   TextPosition,
+  MarkerSize,
 } from './fields';
 
 import {
@@ -141,4 +142,5 @@ export {
   UpdateMenuButtons,
   Dropzone,
   TextPosition,
+  MarkerSize,
 };

--- a/src/default_panels/StyleLayoutPanel.js
+++ b/src/default_panels/StyleLayoutPanel.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import {
   CanvasSize,
   ColorPicker,
+  Dropdown,
   FontSelector,
   PlotlyFold,
   Numeric,
@@ -28,13 +29,16 @@ const StyleLayoutPanel = (props, {localize: _}) => (
       <ColorPicker label={_('Plot Background')} attr="plot_bgcolor" />
       <ColorPicker label={_('Plot Background')} attr="polar.bgcolor" />
       <ColorPicker label={_('Margin Color')} attr="paper_bgcolor" />
-      <Radio
+      <Dropdown
         label="Hover Interaction"
         attr="hovermode"
         options={[
-          {label: _('Enable'), value: 'closest'},
+          {label: _('Closest'), value: 'closest'},
+          {label: _('X Axis'), value: 'x'},
+          {label: _('Y Axis'), value: 'y'},
           {label: _('Disable'), value: false},
         ]}
+        clearable={false}
       />
     </PlotlyFold>
     <PlotlyFold name={_('Title and Fonts')}>

--- a/src/default_panels/StyleTracesPanel.js
+++ b/src/default_panels/StyleTracesPanel.js
@@ -24,8 +24,13 @@ import {
   FillDropdown,
   FontSelector,
   TextPosition,
+  MarkerSize,
 } from '../components';
-import {BinningNumeric, BinningDropdown} from '../components/fields/derived';
+import {
+  BinningNumeric,
+  BinningDropdown,
+  NumericReciprocal,
+} from '../components/fields/derived';
 
 const StyleTracesPanel = (props, {localize: _}) => (
   <TraceAccordion canGroup>
@@ -40,7 +45,6 @@ const StyleTracesPanel = (props, {localize: _}) => (
     />
     <NumericFraction label={_('Opacity')} attr="opacity" />
     <ColorPicker label={_('Color')} attr="color" />
-    <NumericFraction label={_('Hole Size')} attr="hole" />
     <Dropdown
       label={_('Histogram Normalization')}
       options={[
@@ -189,6 +193,17 @@ const StyleTracesPanel = (props, {localize: _}) => (
           {label: _('Unsorted'), value: false},
         ]}
       />
+      <Radio
+        label="Direction"
+        attr="direction"
+        options={[
+          {label: _('Clockwise'), value: 'clockwise'},
+          {label: _('Counterclockwise'), value: 'counterclockwise'},
+        ]}
+      />
+      <Numeric label={_('Rotation')} attr="rotation" />
+      <NumericFraction label={_('Hole Size')} attr="hole" />
+      <NumericFraction label={_('Pull')} attr="pull" />
       <Dropdown
         options={[
           {label: _('Show All'), value: 'all'},
@@ -214,7 +229,17 @@ const StyleTracesPanel = (props, {localize: _}) => (
       <ColorscalePicker label={_('Colorscale')} attr="marker.colorscale" />
       <ColorPicker label={_('Color')} attr="marker.color" />
       <NumericFraction label={_('Opacity')} attr="marker.opacity" />
-      <Numeric label={_('Size')} attr="marker.size" />
+      <MarkerSize label={_('Size')} attr="marker.size" />
+      <Radio
+        label="Size Mode"
+        attr="marker.sizemode"
+        options={[
+          {label: _('Diameter'), value: 'diameter'},
+          {label: _('Area'), value: 'area'},
+        ]}
+      />
+      <Numeric label={_('Minimum Size')} attr="marker.sizemin" />
+      <NumericReciprocal label={_('Size Scale')} attr="marker.sizeref" />
       <SymbolSelector label={_('Symbol')} attr="marker.symbol" />
       <Numeric label={_('Border Width')} attr="marker.line.width" />
       <ColorPicker label={_('Border Color')} attr="marker.line.color" />


### PR DESCRIPTION
**Fields/Bugfixes**

closes #532 and closes #567 

Scatterplot:
- GraphCreate -> size
- StyleTraces -> minmarker size
- StyleLayout -> Hover interactions - no option selected on start

Lineplot:
- StyleTraces -> 'Values shown on hover' doesn’t include ‘text’

Area:
- StyleTraces -> shape - all labels in dropdown are empty when ‘Lines’ is not checked in Display - fixed

Pie:
 - StyleTraces -> missing 'clockwise/counterclockwise', 'rotation', 'border', 'pull apart'


**Added percy tests for:**
- Area
- Line
- Pie
- improved main panel test
