### PR TITLE
Version bump 1391

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "fast-isnumeric": "^1.1.1",
     "immutability-helper": "^2.6.4",
     "plotly-icons": "latest",
-    "plotly.js": "1.38.3",
+    "plotly.js": "1.39.1",
     "prop-types": "^15.5.10",
     "raf": "^3.4.0",
     "react-color": "^2.13.8",

--- a/src/EditorControls.js
+++ b/src/EditorControls.js
@@ -228,19 +228,20 @@ class EditorControls extends Component {
         break;
 
       case EDITOR_ACTIONS.DELETE_TRANSFORM:
-        if (isNumeric(payload.transformIndex)) {
-          for (let i = 0; i < graphDiv.data.length; i++) {
-            if (graphDiv.data[i].uid === payload.traceUid) {
-              graphDiv.data[i].transforms.splice(payload.transformIndex, 1);
-              if (this.props.onUpdate) {
-                this.props.onUpdate(
-                  graphDiv.data.slice(),
-                  graphDiv.layout,
-                  graphDiv._transitionData._frames
-                );
-              }
-              break;
-            }
+        if (
+          isNumeric(payload.transformIndex) &&
+          payload.traceIndex < graphDiv.data.length
+        ) {
+          graphDiv.data[payload.traceIndex].transforms.splice(
+            payload.transformIndex,
+            1
+          );
+          if (this.props.onUpdate) {
+            this.props.onUpdate(
+              graphDiv.data.slice(),
+              graphDiv.layout,
+              graphDiv._transitionData._frames
+            );
           }
         }
         break;

--- a/src/components/fields/TraceSelector.js
+++ b/src/components/fields/TraceSelector.js
@@ -47,12 +47,7 @@ class TraceSelector extends Component {
   }
 
   setTraceDefaults(container, fullContainer, updateContainer) {
-    if (
-      container &&
-      container.uid &&
-      !container.mode &&
-      fullContainer.type === 'scatter'
-    ) {
+    if (container && !container.mode && fullContainer.type === 'scatter') {
       updateContainer({
         type: 'scatter',
         mode: fullContainer.mode || 'markers',

--- a/src/lib/connectTraceToPlot.js
+++ b/src/lib/connectTraceToPlot.js
@@ -31,7 +31,7 @@ export default function connectTraceToPlot(WrappedComponent) {
 
       let fullTrace = {};
       for (let i = 0; i < fullData.length; i++) {
-        if (trace.uid === fullData[i]._fullInput._input.uid) {
+        if (traceIndexes[0] === fullData[i]._fullInput.index) {
           /*
            * Fit transforms are custom transforms in our custom plotly.js bundle,
            * they are different from others as they create an extra trace in the

--- a/src/lib/connectTransformToTrace.js
+++ b/src/lib/connectTransformToTrace.js
@@ -55,7 +55,7 @@ export default function connectTransformToTrace(WrappedComponent) {
         this.context.onUpdate({
           type: EDITOR_ACTIONS.DELETE_TRANSFORM,
           payload: {
-            traceUid: this.context.fullContainer._input.uid,
+            traceIndex: this.context.fullContainer.index,
             transformIndex: this.props.transformIndex,
           },
         });


### PR DESCRIPTION
_plotly.js_ version bump to 1.39.1

Since _plotly.js_ no longer copies UID from `_fullData` to `data`, we can't rely on UID to identify traces and from now on have to use `fullData[i]._fullInput.index`, which will correspond to index in `data`.