### PR TITLE
Gl switch

### DIFF
--- a/dev/App.js
+++ b/dev/App.js
@@ -44,9 +44,17 @@ const config = {mapboxAccessToken: ACCESS_TOKENS.MAPBOX, editable: true};
 const traceTypesConfig = {
   traces: _ => [
     {
-      value: 'scattergl',
+      value: 'scatter',
       icon: 'scatter',
       label: _('Scatter'),
+    },
+    {
+      value: 'line',
+      label: _('Line'),
+    },
+    {
+      value: 'area',
+      label: _('Area'),
     },
     {
       value: 'bar',
@@ -155,6 +163,7 @@ class App extends Component {
           debug
           advancedTraceTypeSelector
           showFieldTooltips
+          // glByDefault
           // traceTypesConfig={traceTypesConfig}
           // makeDefaultTrace={() => ({type: 'scattergl', mode: 'markers'})}
         >

--- a/src/EditorControls.js
+++ b/src/EditorControls.js
@@ -50,6 +50,7 @@ class EditorControls extends Component {
       traceTypesConfig: this.props.traceTypesConfig,
       showFieldTooltips: this.props.showFieldTooltips,
       glByDefault: this.props.glByDefault,
+      mapBoxAccess: this.props.mapBoxAccess,
     };
   }
 
@@ -317,6 +318,7 @@ EditorControls.propTypes = {
   traceTypesConfig: PropTypes.object,
   makeDefaultTrace: PropTypes.func,
   glByDefault: PropTypes.bool,
+  mapBoxAccess: PropTypes.bool,
 };
 
 EditorControls.defaultProps = {
@@ -355,6 +357,7 @@ EditorControls.childContextTypes = {
   traceTypesConfig: PropTypes.object,
   showFieldTooltips: PropTypes.bool,
   glByDefault: PropTypes.bool,
+  mapBoxAccess: PropTypes.bool,
 };
 
 export default EditorControls;

--- a/src/EditorControls.js
+++ b/src/EditorControls.js
@@ -49,6 +49,7 @@ class EditorControls extends Component {
       plotly: this.props.plotly,
       traceTypesConfig: this.props.traceTypesConfig,
       showFieldTooltips: this.props.showFieldTooltips,
+      glByDefault: this.props.glByDefault,
     };
   }
 
@@ -121,7 +122,14 @@ class EditorControls extends Component {
 
         // can't use default prop because plotly.js mutates it:
         // https://github.com/plotly/react-chart-editor/issues/509
-        graphDiv.data.push(this.props.makeDefaultTrace());
+        graphDiv.data.push(
+          this.props.makeDefaultTrace
+            ? this.props.makeDefaultTrace()
+            : {
+                type: `scatter${this.props.glByDefault ? 'gl' : ''}`,
+                mode: 'markers',
+              }
+        );
 
         if (this.props.afterAddTrace) {
           this.props.afterAddTrace(payload);
@@ -308,12 +316,12 @@ EditorControls.propTypes = {
   showFieldTooltips: PropTypes.bool,
   traceTypesConfig: PropTypes.object,
   makeDefaultTrace: PropTypes.func,
+  glByDefault: PropTypes.bool,
 };
 
 EditorControls.defaultProps = {
   showFieldTooltips: false,
   locale: 'en',
-  makeDefaultTrace: () => ({type: 'scatter', mode: 'markers'}),
   traceTypesConfig: {
     categories: _ => categoryLayout(_),
     traces: _ => traceTypes(_),
@@ -346,6 +354,7 @@ EditorControls.childContextTypes = {
   plotSchema: PropTypes.object,
   traceTypesConfig: PropTypes.object,
   showFieldTooltips: PropTypes.bool,
+  glByDefault: PropTypes.bool,
 };
 
 export default EditorControls;

--- a/src/PlotlyEditor.js
+++ b/src/PlotlyEditor.js
@@ -28,6 +28,9 @@ class PlotlyEditor extends Component {
             srcConverters={this.props.srcConverters}
             makeDefaultTrace={this.props.makeDefaultTrace}
             glByDefault={this.props.glByDefault}
+            mapBoxAccess={Boolean(
+              this.props.config && this.props.config.mapboxAccessToken
+            )}
           >
             {this.props.children}
           </EditorControls>

--- a/src/PlotlyEditor.js
+++ b/src/PlotlyEditor.js
@@ -27,6 +27,7 @@ class PlotlyEditor extends Component {
             showFieldTooltips={this.props.showFieldTooltips}
             srcConverters={this.props.srcConverters}
             makeDefaultTrace={this.props.makeDefaultTrace}
+            glByDefault={this.props.glByDefault}
           >
             {this.props.children}
           </EditorControls>
@@ -77,6 +78,7 @@ PlotlyEditor.propTypes = {
     fromSrc: PropTypes.func.isRequired,
   }),
   makeDefaultTrace: PropTypes.func,
+  glByDefault: PropTypes.bool,
 };
 
 PlotlyEditor.defaultProps = {

--- a/src/components/containers/Modal.js
+++ b/src/components/containers/Modal.js
@@ -21,6 +21,26 @@ const ModalContent = ({children}) => (
 );
 
 class Modal extends Component {
+  constructor(props) {
+    super(props);
+    this.escFunction = this.escFunction.bind(this);
+  }
+
+  escFunction(event) {
+    const escKeyCode = 27;
+    if (event.keyCode === escKeyCode) {
+      this.context.handleClose();
+    }
+  }
+
+  componentDidMount() {
+    document.addEventListener('keydown', this.escFunction, false);
+  }
+
+  componentWillUnmount() {
+    document.removeEventListener('keydown', this.escFunction, false);
+  }
+
   render() {
     const {children, title} = this.props;
     let classes = 'modal';

--- a/src/components/widgets/TraceTypeSelector.js
+++ b/src/components/widgets/TraceTypeSelector.js
@@ -97,13 +97,18 @@ class TraceTypeSelector extends Component {
     const {fullValue} = this.props;
     const {
       traceTypesConfig: {traces, categories, complex},
+      mapBoxAccess,
       localize: _,
     } = this.context;
 
     return categories(_).map((category, i) => {
-      const items = traces(_)
+      let items = traces(_)
         .filter(({category: {value}}) => value === category.value)
         .filter(i => i.value !== 'scattergl' && i.value !== 'scatterpolargl');
+
+      if (!mapBoxAccess) {
+        items = items.filter(i => i.value !== 'scattermapbox');
+      }
 
       const MAX_ITEMS = 4;
 
@@ -227,6 +232,7 @@ TraceTypeSelector.contextTypes = {
   traceTypesConfig: PropTypes.object,
   handleClose: PropTypes.func,
   localize: PropTypes.func,
+  mapBoxAccess: PropTypes.bool,
 };
 TraceTypeSelectorButton.propTypes = {
   handleClick: PropTypes.func.isRequired,

--- a/src/components/widgets/TraceTypeSelector.js
+++ b/src/components/widgets/TraceTypeSelector.js
@@ -2,6 +2,7 @@ import React, {Component} from 'react';
 import PropTypes from 'prop-types';
 import {SearchIcon, ThumnailViewIcon, GraphIcon} from 'plotly-icons';
 import Modal from 'components/containers/Modal';
+import {glAvailable} from 'components/fields/TraceSelector';
 import {
   traceTypeToPlotlyInitFigure,
   renderTraceIcon,
@@ -75,8 +76,20 @@ const Item = ({item, active, handleClick, actions, showActions, complex}) => {
 
 class TraceTypeSelector extends Component {
   selectAndClose(value) {
+    const {
+      updateContainer,
+      glByDefault,
+      fullContainer: {type},
+    } = this.props;
     const computedValue = traceTypeToPlotlyInitFigure(value);
-    this.props.updateContainer(computedValue);
+    if (
+      (type.endsWith('gl') || (!glAvailable(type) && glByDefault)) &&
+      glAvailable(computedValue.type) &&
+      !computedValue.type.endsWith('gl')
+    ) {
+      computedValue.type = computedValue.type + 'gl';
+    }
+    updateContainer(computedValue);
     this.context.handleClose();
   }
 
@@ -207,6 +220,8 @@ export class TraceTypeSelectorButton extends Component {
 TraceTypeSelector.propTypes = {
   updateContainer: PropTypes.func,
   fullValue: PropTypes.string,
+  fullContainer: PropTypes.object,
+  glByDefault: PropTypes.bool,
 };
 TraceTypeSelector.contextTypes = {
   traceTypesConfig: PropTypes.object,

--- a/src/components/widgets/TraceTypeSelector.js
+++ b/src/components/widgets/TraceTypeSelector.js
@@ -101,9 +101,9 @@ class TraceTypeSelector extends Component {
     } = this.context;
 
     return categories(_).map((category, i) => {
-      const items = traces(_).filter(
-        ({category: {value}}) => value === category.value
-      );
+      const items = traces(_)
+        .filter(({category: {value}}) => value === category.value)
+        .filter(i => i.value !== 'scattergl' && i.value !== 'scatterpolargl');
 
       const MAX_ITEMS = 4;
 

--- a/src/lib/customTraceType.js
+++ b/src/lib/customTraceType.js
@@ -1,31 +1,37 @@
 export function plotlyTraceToCustomTrace(trace) {
-  const type = trace.type || 'scatter';
+  const gl = 'gl';
+  const type = trace.type.endsWith(gl)
+    ? trace.type.slice(0, -gl.length)
+    : trace.type || 'scatter';
+
   if (
-    type === 'scatter' &&
+    (type === 'scatter' || type === 'scattergl') &&
     ['tozeroy', 'tozerox', 'tonexty', 'tonextx', 'toself', 'tonext'].includes(
       trace.fill
     )
   ) {
     return 'area';
   } else if (
-    type === 'scatter' &&
+    (type === 'scatter' || type === 'scattergl') &&
     (trace.mode === 'lines' || trace.mode === 'lines+markers')
   ) {
     return 'line';
   } else if (type === 'scatter3d' && trace.mode === 'lines') {
     return 'line3d';
   }
-  return trace.type;
+  return type;
 }
 
-export function traceTypeToPlotlyInitFigure(traceType) {
+export function traceTypeToPlotlyInitFigure(traceType, gl = '') {
   switch (traceType) {
     case 'line':
-      return {type: 'scatter', mode: 'lines', fill: 'none'};
+      return {type: 'scatter' + gl, mode: 'lines', fill: 'none'};
     case 'scatter':
-      return {type: 'scatter', mode: 'markers', fill: 'none'};
+      return {type: 'scatter' + gl, mode: 'markers', fill: 'none'};
     case 'area':
-      return {type: 'scatter', fill: 'tozeroy'};
+      return {type: 'scatter' + gl, fill: 'tozeroy'};
+    case 'scatterpolar':
+      return {type: 'scatterpolar' + gl};
     case 'ohlc':
       return {
         type: 'ohlc',

--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -58,7 +58,10 @@ function renderTraceIcon(trace, prefix = 'Plot') {
   if (!trace) {
     return null;
   }
-  const componentName = `${prefix}${pascalCase(trace)}Icon`;
+  const gl = 'gl';
+  const componentName = `${prefix}${pascalCase(
+    trace.endsWith(gl) ? trace.slice(0, -gl.length) : trace
+  )}Icon`;
   return PlotlyIcons[componentName]
     ? PlotlyIcons[componentName]
     : PlotlyIcons.PlotLineIcon;

--- a/src/lib/traceTypes.js
+++ b/src/lib/traceTypes.js
@@ -12,10 +12,10 @@ export const chartCategory = _ => {
       value: 'CHARTS_3D',
       label: _('3D charts'),
     },
-    // FINANCIAL: {
-    //   value: 'FINANCIAL',
-    //   label: _('Finance'),
-    // },
+    FINANCIAL: {
+      value: 'FINANCIAL',
+      label: _('Finance'),
+    },
     DISTRIBUTIONS: {
       value: 'DISTRIBUTIONS',
       label: _('Distributions'),
@@ -28,9 +28,9 @@ export const chartCategory = _ => {
       value: 'SPECIALIZED',
       label: _('Specialized'),
     },
-    WEB_GL: {
-      value: 'WEB_GL',
-      label: _('WebGL'),
+    THREE_D: {
+      value: '3D',
+      label: _('3D'),
     },
   };
 };
@@ -38,11 +38,11 @@ export const chartCategory = _ => {
 // Layout specification for TraceTypeSelector.js
 export const categoryLayout = _ => [
   chartCategory(_).SIMPLE,
-  chartCategory(_).WEB_GL,
   chartCategory(_).DISTRIBUTIONS,
-  chartCategory(_).SPECIALIZED,
+  chartCategory(_).THREE_D,
   chartCategory(_).MAPS,
-  // chartCategory(_).FINANCIAL,
+  chartCategory(_).FINANCIAL,
+  chartCategory(_).SPECIALIZED,
 ];
 
 export const traceTypes = _ => [
@@ -89,22 +89,22 @@ export const traceTypes = _ => [
   {
     value: 'scatter3d',
     label: _('3D Scatter'),
-    category: chartCategory(_).WEB_GL,
+    category: chartCategory(_).THREE_D,
   },
   {
     value: 'line3d',
     label: _('3D Line'),
-    category: chartCategory(_).WEB_GL,
+    category: chartCategory(_).THREE_D,
   },
   {
     value: 'surface',
     label: _('3D Surface'),
-    category: chartCategory(_).WEB_GL,
+    category: chartCategory(_).THREE_D,
   },
   {
     value: 'mesh3d',
     label: _('3D Mesh'),
-    category: chartCategory(_).WEB_GL,
+    category: chartCategory(_).THREE_D,
   },
   {
     value: 'box',
@@ -174,34 +174,34 @@ export const traceTypes = _ => [
   {
     value: 'candlestick',
     label: _('Candlestick'),
-    category: chartCategory(_).SPECIALIZED,
+    category: chartCategory(_).FINANCIAL,
   },
   {
     value: 'ohlc',
     label: _('OHLC'),
-    category: chartCategory(_).SPECIALIZED,
+    category: chartCategory(_).FINANCIAL,
   },
   // {
   //   value: 'pointcloud',
   //   label: _('Point Cloud'),
-  //   category: chartCategory(_).WEB_GL,
+  //   category: chartCategory(_).THREE_D,
   // },
   {
     value: 'scattergl',
     icon: 'scatter',
-    label: _('Scatter GL'),
-    category: chartCategory(_).WEB_GL,
+    label: _('Scatter'),
+    category: chartCategory(_).THREE_D,
   },
   {
     value: 'scatterpolargl',
     icon: 'scatterpolar',
-    label: _('Polar Scatter GL'),
-    category: chartCategory(_).WEB_GL,
+    label: _('Polar Scatter'),
+    category: chartCategory(_).THREE_D,
   },
   // {
   //   value: 'heatmapgl',
   //   icon: 'heatmap',
   //   label: _('Heatmap GL'),
-  //   category: chartCategory(_).WEB_GL,
+  //   category: chartCategory(_).THREE_D,
   // },
 ];


### PR DESCRIPTION
closes #565 
closes #537
closes #545

- add "GL Acceleration" switch
- remove *gl traces from UI
- rebalance trace selection modal
- make modal close on Esc key
- fix icon for scattergl
- don't display 'Satellite maps' when no mapbox token exists