### PR TITLE
Color multiple traces

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "prop-types": "^15.5.10",
     "raf": "^3.4.0",
     "react-color": "^2.13.8",
-    "react-colorscales": "0.5.7",
+    "react-colorscales": "0.5.8",
     "react-dropzone": "^4.2.9",
     "react-plotly.js": "^2.2.0",
     "react-rangeslider": "^2.2.0",

--- a/src/components/containers/TraceAccordion.js
+++ b/src/components/containers/TraceAccordion.js
@@ -86,16 +86,16 @@ class TraceAccordion extends Component {
         <TraceRequiredPanel noPadding>
           <Tabs>
             <TabList>
-              <Tab>{_('All Traces')}</Tab>
-              <Tab>{_('Individual')}</Tab>
+              <Tab>{_('Individually')}</Tab>
+              <Tab>{_('By Type')}</Tab>
             </TabList>
-            <TabPanel>
-              <PlotlyPanel>{groupedTraces ? groupedTraces : null}</PlotlyPanel>
-            </TabPanel>
             <TabPanel>
               <PlotlyPanel>
                 {individualTraces ? individualTraces : null}
               </PlotlyPanel>
+            </TabPanel>
+            <TabPanel>
+              <PlotlyPanel>{groupedTraces ? groupedTraces : null}</PlotlyPanel>
             </TabPanel>
           </Tabs>
         </TraceRequiredPanel>

--- a/src/components/fields/Colorscale.js
+++ b/src/components/fields/Colorscale.js
@@ -47,4 +47,14 @@ Colorscale.propTypes = {
   ...Field.propTypes,
 };
 
-export default connectToContainer(Colorscale);
+export default connectToContainer(Colorscale, {
+  modifyPlotProps: (props, context, plotProps) => {
+    if (plotProps.fullValue && typeof plotProps.fullValue === 'string') {
+      plotProps.fullValue =
+        context.fullData &&
+        context.fullData
+          .filter(t => context.traceIndexes.includes(t.index))
+          .map(t => [0, t.marker.color]);
+    }
+  },
+});

--- a/src/components/fields/Colorscale.js
+++ b/src/components/fields/Colorscale.js
@@ -35,6 +35,7 @@ class Colorscale extends Component {
         <ColorscalePicker
           selected={colorscale}
           onColorscaleChange={this.onUpdate}
+          initialCategory={this.props.initialCategory}
         />
       </Field>
     );
@@ -44,6 +45,7 @@ class Colorscale extends Component {
 Colorscale.propTypes = {
   fullValue: PropTypes.any,
   updatePlot: PropTypes.func,
+  initialCategory: PropTypes.string,
   ...Field.propTypes,
 };
 

--- a/src/components/fields/Colorscale.js
+++ b/src/components/fields/Colorscale.js
@@ -51,7 +51,13 @@ Colorscale.propTypes = {
 
 export default connectToContainer(Colorscale, {
   modifyPlotProps: (props, context, plotProps) => {
-    if (plotProps.fullValue && typeof plotProps.fullValue === 'string') {
+    if (
+      props.attr === 'marker.color' &&
+      context.fullData
+        .filter(t => context.traceIndexes.includes(t.index))
+        .every(t => t.marker && t.marker.color) &&
+      (plotProps.fullValue && typeof plotProps.fullValue === 'string')
+    ) {
       plotProps.fullValue =
         context.fullData &&
         context.fullData

--- a/src/components/fields/DataSelector.js
+++ b/src/components/fields/DataSelector.js
@@ -108,6 +108,7 @@ export class UnconnectedDataSelector extends Component {
           optionRenderer={this.context.dataSourceOptionRenderer}
           valueRenderer={this.context.dataSourceValueRenderer}
           clearable={true}
+          placeholder={this.props.placeholder}
         />
       </Field>
     );
@@ -118,6 +119,7 @@ UnconnectedDataSelector.propTypes = {
   fullValue: PropTypes.any,
   updatePlot: PropTypes.func,
   container: PropTypes.object,
+  placeholder: PropTypes.string,
   ...Field.propTypes,
 };
 

--- a/src/components/fields/MarkerColor.js
+++ b/src/components/fields/MarkerColor.js
@@ -100,16 +100,21 @@ class UnconnectedMarkerColor extends Component {
 
   setColors(colorscale) {
     const numberOfTraces = this.context.traceIndexes.length;
-    const adjustedScale = getColorscale(
-      colorscale.map(c => c[1]),
-      numberOfTraces
-    );
-    const updates = adjustedScale.map(color => ({
+    const colors = colorscale.map(c => c[1]);
+
+    let adjustedColors = getColorscale(colors, numberOfTraces);
+    if (adjustedColors.every(c => c === adjustedColors[0])) {
+      adjustedColors = colors;
+    }
+
+    const updates = adjustedColors.map(color => ({
       ['marker.color']: color,
     }));
+
     this.setState({
-      colorscale: adjustedScale,
+      colorscale: adjustedColors,
     });
+
     this.context.updateContainer(updates);
   }
 

--- a/src/components/fields/MarkerColor.js
+++ b/src/components/fields/MarkerColor.js
@@ -149,6 +149,7 @@ class UnconnectedMarkerColor extends Component {
               attr="marker.color"
               updatePlot={this.setColors}
               colorscale={this.state.colorscale}
+              initialCategory={'categorical'}
             />
           )}
         </div>

--- a/src/components/fields/MarkerColor.js
+++ b/src/components/fields/MarkerColor.js
@@ -49,20 +49,22 @@ class UnconnectedMarkerColor extends Component {
   }
 
   setType(type) {
-    this.setState({type: type});
-    this.props.updatePlot(this.state.value[type]);
-    if (type === 'constant') {
-      this.context.updateContainer({
-        ['marker.colorsrc']: null,
-        ['marker.colorscale']: null,
-      });
-      this.setState({colorscale: null});
-    } else {
-      this.context.updateContainer({
-        ['marker.color']: null,
-        ['marker.colorsrc']: null,
-        ['marker.colorscale']: [],
-      });
+    if (this.state.type !== type) {
+      this.setState({type: type});
+      this.props.updatePlot(this.state.value[type]);
+      if (type === 'constant') {
+        this.context.updateContainer({
+          ['marker.colorsrc']: null,
+          ['marker.colorscale']: null,
+        });
+        this.setState({colorscale: null});
+      } else {
+        this.context.updateContainer({
+          ['marker.color']: null,
+          ['marker.colorsrc']: null,
+          ['marker.colorscale']: [],
+        });
+      }
     }
   }
 

--- a/src/components/fields/MarkerColor.js
+++ b/src/components/fields/MarkerColor.js
@@ -166,21 +166,30 @@ class UnconnectedMarkerColor extends Component {
 
   renderVariableControls() {
     const _ = this.context.localize;
+    const multiValued =
+      (this.props.container &&
+        this.props.container.marker &&
+        (this.props.container.marker.colorscale &&
+          this.props.container.marker.colorscale === MULTI_VALUED)) ||
+      (this.props.container.marker.colorsrc &&
+        this.props.container.marker.colorsrc === MULTI_VALUED);
     return (
-      <Fragment>
+      <Field multiValued={multiValued}>
         <DataSelector
+          suppressMultiValuedMessage
           attr="marker.color"
           placeholder={_('Select a Data Option')}
         />
         {this.props.container.marker &&
         this.props.container.marker.colorscale === MULTI_VALUED ? null : (
           <Colorscale
+            suppressMultiValuedMessage
             attr="marker.colorscale"
             updatePlot={this.setColorScale}
             colorscale={this.state.colorscale}
           />
         )}
-      </Fragment>
+      </Field>
     );
   }
 
@@ -195,20 +204,22 @@ class UnconnectedMarkerColor extends Component {
 
     return (
       <Fragment>
-        <Field {...this.props} multiValued={this.isMultiValued()} attr={attr}>
-          <RadioBlocks
-            options={options}
-            activeOption={type}
-            onOptionChange={this.setType}
-          />
+        <Field {...this.props} attr={attr}>
+          <Field multiValued={this.isMultiValued() && !this.state.type}>
+            <RadioBlocks
+              options={options}
+              activeOption={type}
+              onOptionChange={this.setType}
+            />
 
-          {!type ? null : (
-            <Info>
-              {type === 'constant'
-                ? _('All points in a trace are colored in the same color.')
-                : _('Each point in a trace is colored according to data.')}
-            </Info>
-          )}
+            {!type ? null : (
+              <Info>
+                {type === 'constant'
+                  ? _('All points in a trace are colored in the same color.')
+                  : _('Each point in a trace is colored according to data.')}
+              </Info>
+            )}
+          </Field>
 
           {!type
             ? null

--- a/src/components/widgets/ColorscalePicker.js
+++ b/src/components/widgets/ColorscalePicker.js
@@ -88,8 +88,4 @@ Scale.contextTypes = {
   localize: PropTypes.func,
 };
 
-Scale.contextTypes = {
-  localize: PropTypes.func,
-};
-
 export default Scale;

--- a/src/components/widgets/ColorscalePicker.js
+++ b/src/components/widgets/ColorscalePicker.js
@@ -8,11 +8,11 @@ import PropTypes from 'prop-types';
 import React, {Component, Fragment} from 'react';
 
 class Scale extends Component {
-  constructor() {
-    super();
+  constructor(props) {
+    super(props);
 
     this.state = {
-      selectedColorscaleType: 'sequential',
+      selectedColorscaleType: props.initialCategory || 'sequential',
       showColorscalePicker: false,
     };
 
@@ -82,6 +82,7 @@ Scale.propTypes = {
   onColorscaleChange: PropTypes.func,
   selected: PropTypes.array,
   label: PropTypes.string,
+  initialCategory: PropTypes.string,
 };
 
 Scale.contextTypes = {

--- a/src/default_panels/StyleTracesPanel.js
+++ b/src/default_panels/StyleTracesPanel.js
@@ -225,7 +225,11 @@ const StyleTracesPanel = (props, {localize: _}) => (
       />
       <NumericFraction label={_('Jitter')} attr="jitter" />
       <Numeric label={_('Position')} attr="pointpos" step={0.1} showSlider />
-      <MarkerColor label={_('Color')} attr="marker.color" />
+      <MarkerColor
+        suppressMultiValuedMessage
+        label={_('Color')}
+        attr="marker.color"
+      />
       <NumericFraction label={_('Opacity')} attr="marker.opacity" />
       <MarkerSize label={_('Size')} attr="marker.size" />
       <Radio

--- a/src/lib/connectToContainer.js
+++ b/src/lib/connectToContainer.js
@@ -17,6 +17,7 @@ export const containerConnectedContextTypes = {
   onUpdate: PropTypes.func,
   plotly: PropTypes.object,
   updateContainer: PropTypes.func,
+  traceIndexes: PropTypes.array,
 };
 
 export default function connectToContainer(WrappedComponent, config = {}) {

--- a/src/lib/connectTraceToPlot.js
+++ b/src/lib/connectTraceToPlot.js
@@ -72,6 +72,7 @@ export default function connectTraceToPlot(WrappedComponent) {
         deleteContainer: this.deleteTrace,
         container: trace,
         fullContainer: fullTrace,
+        traceIndexes: this.props.traceIndexes,
       };
 
       if (traceIndexes.length > 1) {
@@ -108,13 +109,25 @@ export default function connectTraceToPlot(WrappedComponent) {
 
     updateTrace(update) {
       if (this.context.onUpdate) {
-        this.context.onUpdate({
-          type: EDITOR_ACTIONS.UPDATE_TRACES,
-          payload: {
-            update,
-            traceIndexes: this.props.traceIndexes,
-          },
-        });
+        if (Array.isArray(update)) {
+          update.forEach((u, i) => {
+            this.context.onUpdate({
+              type: EDITOR_ACTIONS.UPDATE_TRACES,
+              payload: {
+                update: u,
+                traceIndexes: [this.props.traceIndexes[i]],
+              },
+            });
+          });
+        } else {
+          this.context.onUpdate({
+            type: EDITOR_ACTIONS.UPDATE_TRACES,
+            payload: {
+              update,
+              traceIndexes: this.props.traceIndexes,
+            },
+          });
+        }
       }
     }
 
@@ -156,6 +169,7 @@ export default function connectTraceToPlot(WrappedComponent) {
     defaultContainer: PropTypes.object,
     container: PropTypes.object,
     fullContainer: PropTypes.object,
+    traceIndexes: PropTypes.array,
   };
 
   const {plotly_editor_traits} = WrappedComponent;

--- a/src/styles/components/fields/_main.scss
+++ b/src/styles/components/fields/_main.scss
@@ -1,2 +1,3 @@
 @import 'field';
 @import 'symbolselector';
+@import 'markercolor';

--- a/src/styles/components/fields/_markercolor.scss
+++ b/src/styles/components/fields/_markercolor.scss
@@ -1,0 +1,3 @@
+.markercolor-constantcontrols__container {
+  margin-top: var(--spacing-quarter-unit);
+}

--- a/src/styles/components/widgets/_colorpicker.scss
+++ b/src/styles/components/widgets/_colorpicker.scss
@@ -22,7 +22,7 @@ $slider-picker-height: 10px;
   padding: var(--spacing-eighth-unit);
 
   &__popover {
-    left: -90px;
+    left: -60px;
     position: absolute;
     top: 100%;
     margin: var(--spacing-quarter-unit) 0 var(--spacing-base-unit);
@@ -71,13 +71,13 @@ $slider-picker-height: 10px;
   }
   &__custom-input {
     padding: var(--spacing-quarter-unit) var(--spacing-half-unit);
-    input{
+    input {
       border: var(--border-default) !important;
       box-shadow: none !important;
       background-color: var(--color-background-inputs);
       color: var(--color-text-dark);
     }
-    input + span{
+    input + span {
       color: var(--color-text) !important;
     }
   }
@@ -117,9 +117,9 @@ $slider-picker-height: 10px;
 
   &__preset-colors {
     margin: 0 var(--spacing-half-unit);
-    & > div{
+    & > div {
       border-top: var(--border-light) !important; // inline style override
-      padding:var(--spacing-half-unit) !important;
+      padding: var(--spacing-half-unit) !important;
       padding-bottom: var(--spacing-quarter-unit) !important;
     }
   }

--- a/src/styles/components/widgets/_colorscalepicker.scss
+++ b/src/styles/components/widgets/_colorscalepicker.scss
@@ -24,5 +24,5 @@
 }
 
 .customPickerContainer {
-  margin-top: 10px;
+  margin-top: var(--spacing-quarter-unit);
 }


### PR DESCRIPTION
Enables coloring multiple traces at once, like on cloud, and includes #10053 improvements.
![ex](https://user-images.githubusercontent.com/4257572/43284704-a6c0dfee-90ea-11e8-8277-40101475c011.gif)
