### PR TITLE
Style splits

### DIFF
--- a/src/EditorControls.js
+++ b/src/EditorControls.js
@@ -7,7 +7,8 @@ import {
   shamefullyAdjustAxisRef,
   shamefullyAdjustGeo,
   shamefullyAddTableColumns,
-  shamefullyCreateSplitStyles,
+  shamefullyCreateSplitStyleProps,
+  shamefullyAdjustSplitStyleTargetContainers,
 } from './shame';
 import {EDITOR_ACTIONS} from './lib/constants';
 import isNumeric from 'fast-isnumeric';
@@ -67,6 +68,7 @@ class EditorControls extends Component {
         shamefullyClearAxisTypes(graphDiv, payload);
         shamefullyAdjustAxisRef(graphDiv, payload);
         shamefullyAddTableColumns(graphDiv, payload);
+        shamefullyAdjustSplitStyleTargetContainers(graphDiv, payload);
 
         for (let i = 0; i < payload.traceIndexes.length; i++) {
           for (const attr in payload.update) {
@@ -79,7 +81,7 @@ class EditorControls extends Component {
             const value = payload.update[attr];
 
             if (splitTraceGroup) {
-              props = shamefullyCreateSplitStyles(
+              props = shamefullyCreateSplitStyleProps(
                 graphDiv,
                 attr,
                 traceIndex,

--- a/src/EditorControls.js
+++ b/src/EditorControls.js
@@ -7,6 +7,7 @@ import {
   shamefullyAdjustAxisRef,
   shamefullyAdjustGeo,
   shamefullyAddTableColumns,
+  shamefullyCreateSplitStyles,
 } from './shame';
 import {EDITOR_ACTIONS} from './lib/constants';
 import isNumeric from 'fast-isnumeric';
@@ -70,12 +71,27 @@ class EditorControls extends Component {
         for (let i = 0; i < payload.traceIndexes.length; i++) {
           for (const attr in payload.update) {
             const traceIndex = payload.traceIndexes[i];
-            const prop = nestedProperty(graphDiv.data[traceIndex], attr);
+            const splitTraceGroup = payload.splitTraceGroup
+              ? payload.splitTraceGroup.toString()
+              : null;
+
+            let props = [nestedProperty(graphDiv.data[traceIndex], attr)];
             const value = payload.update[attr];
 
-            if (value !== void 0) {
-              prop.set(value);
+            if (splitTraceGroup) {
+              props = shamefullyCreateSplitStyles(
+                graphDiv,
+                attr,
+                traceIndex,
+                splitTraceGroup
+              );
             }
+
+            props.forEach(p => {
+              if (value !== void 0) {
+                p.set(value);
+              }
+            });
           }
         }
 

--- a/src/components/containers/TraceAccordion.js
+++ b/src/components/containers/TraceAccordion.js
@@ -137,7 +137,7 @@ class TraceAccordion extends Component {
       if (this.filteredTraces.length === 1) {
         return (
           <TraceRequiredPanel>
-            <PlotlyPanel>{this.renderUngroupedTraceFolds()}</PlotlyPanel>
+            {this.renderUngroupedTraceFolds()}
           </TraceRequiredPanel>
         );
       }

--- a/src/components/containers/TraceAccordion.js
+++ b/src/components/containers/TraceAccordion.js
@@ -42,7 +42,7 @@ class TraceAccordion extends Component {
     const fullDataArrayPositionsByTraceType = {};
 
     this.filteredTraces.forEach((trace, index) => {
-      const traceType = plotlyTraceToCustomTrace(trace.type);
+      const traceType = plotlyTraceToCustomTrace(trace);
       if (!dataArrayPositionsByTraceType[traceType]) {
         dataArrayPositionsByTraceType[traceType] = [];
       }

--- a/src/components/containers/TraceAccordion.js
+++ b/src/components/containers/TraceAccordion.js
@@ -10,51 +10,60 @@ import {Tab, Tabs, TabList, TabPanel} from 'react-tabs';
 const TraceFold = connectTraceToPlot(PlotlyFold);
 
 class TraceAccordion extends Component {
-  renderGroupedTraceFolds(groupedTraces) {
-    if (this.props.useFullData) {
-      const dataArrayPositionsByTraceType = {};
-      const fullDataArrayPositionsByTraceType = {};
+  constructor(props, context) {
+    super(props, context);
+    this.setLocals(props, context);
+  }
 
-      Object.keys(groupedTraces).forEach(traceType => {
-        const dataIndexes = [];
-        const fullDataIndexes = [];
+  componentWillReceiveProps(nextProps, nextContext) {
+    this.setLocals(nextProps, nextContext);
+  }
 
-        this.context.fullData.forEach((trace, fullDataIndex) => {
-          if (trace.type === traceType && trace._expandedIndex) {
-            fullDataIndexes.push(trace._expandedIndex);
-          }
-          if (trace.type === traceType && !trace._expandedIndex) {
-            fullDataIndexes.push(fullDataIndex);
-          }
-          if (trace.type === traceType) {
-            dataIndexes.push(trace.index);
-          }
-        });
+  setLocals(props, context) {
+    // we don't want to include analysis transforms when we're in the create panel
+    const base = props.canGroup ? context.fullData : context.data;
 
-        dataArrayPositionsByTraceType[traceType] = dataIndexes;
-        fullDataArrayPositionsByTraceType[traceType] = fullDataIndexes;
-      });
+    this.filteredTracesFullDataPositions = [];
+    this.filteredTraces = base.filter((t, i) => {
+      if (props.excludeFits) {
+        return !(t.transforms && t.transforms.every(tr => tr.type === 'fit'));
+      }
+      this.filteredTracesFullDataPositions.push(i);
+      return true;
+    });
+  }
 
-      return Object.keys(groupedTraces).map((traceType, index) => {
-        return (
-          <TraceFold
-            key={index}
-            traceIndexes={dataArrayPositionsByTraceType[traceType]}
-            name={traceType}
-            fullDataArrayPosition={fullDataArrayPositionsByTraceType[traceType]}
-          >
-            {this.props.children}
-          </TraceFold>
-        );
-      });
+  renderGroupedTraceFolds() {
+    if (!this.filteredTraces.length || this.filteredTraces.length < 2) {
+      return null;
     }
 
-    return Object.keys(groupedTraces).map((traceType, index) => {
+    const dataArrayPositionsByTraceType = {};
+    const fullDataArrayPositionsByTraceType = {};
+
+    this.filteredTraces.forEach((trace, index) => {
+      const traceType = plotlyTraceToCustomTrace(trace.type);
+      if (!dataArrayPositionsByTraceType[traceType]) {
+        dataArrayPositionsByTraceType[traceType] = [];
+      }
+
+      if (!fullDataArrayPositionsByTraceType[traceType]) {
+        fullDataArrayPositionsByTraceType[traceType] = [];
+      }
+
+      dataArrayPositionsByTraceType[traceType].push(trace.index);
+      fullDataArrayPositionsByTraceType[traceType].push(
+        this.filteredTracesFullDataPositions[index]
+      );
+    });
+
+    return Object.keys(fullDataArrayPositionsByTraceType).map((type, index) => {
       return (
         <TraceFold
           key={index}
-          traceIndexes={groupedTraces[traceType]}
-          name={traceType}
+          traceIndexes={dataArrayPositionsByTraceType[type]}
+          name={type}
+          fullDataArrayPosition={fullDataArrayPositionsByTraceType[type]}
         >
           {this.props.children}
         </TraceFold>
@@ -62,24 +71,32 @@ class TraceAccordion extends Component {
     });
   }
 
-  renderIndividualTraceFolds(filteredTraces, filteredTracesFullDataPositions) {
-    if (this.props.useFullData) {
-      return filteredTraces.map((d, i) => {
-        return (
-          <TraceFold
-            key={i}
-            traceIndexes={[d.index]}
-            canDelete={this.props.canAdd}
-            messageIfEmpty={this.props.messageIfEmptyFold}
-            fullDataArrayPosition={[filteredTracesFullDataPositions[i]]}
-          >
-            {this.props.children}
-          </TraceFold>
-        );
-      });
+  renderUngroupedTraceFolds() {
+    if (!this.filteredTraces.length) {
+      return null;
     }
 
-    return filteredTraces.map((d, i) => {
+    return this.filteredTraces.map((d, i) => {
+      return (
+        <TraceFold
+          key={i}
+          traceIndexes={[d.index]}
+          canDelete={this.props.canAdd}
+          messageIfEmpty={this.props.messageIfEmptyFold}
+          fullDataArrayPosition={[this.filteredTracesFullDataPositions[i]]}
+        >
+          {this.props.children}
+        </TraceFold>
+      );
+    });
+  }
+
+  renderTraceFolds() {
+    if (!this.filteredTraces.length) {
+      return null;
+    }
+
+    return this.filteredTraces.map((d, i) => {
       return (
         <TraceFold
           key={i}
@@ -93,111 +110,59 @@ class TraceAccordion extends Component {
     });
   }
 
-  renderCanAddPanel(filteredTraces, filteredTracesFullDataPositions) {
+  render() {
+    const {canAdd, canGroup} = this.props;
     const _ = this.context.localize;
 
-    const addAction = {
-      label: _('Trace'),
-      handler: ({onUpdate}) => {
-        if (onUpdate) {
-          onUpdate({
-            type: EDITOR_ACTIONS.ADD_TRACE,
-          });
-        }
-      },
-    };
-
-    return (
-      <PlotlyPanel addAction={addAction}>
-        {filteredTraces.length
-          ? this.renderIndividualTraceFolds(
-              filteredTraces,
-              filteredTracesFullDataPositions
-            )
-          : null}
-      </PlotlyPanel>
-    );
-  }
-
-  render() {
-    const {data = [], localize: _, fullData = []} = this.context;
-    const {canAdd, canGroup, excludeFits, useFullData} = this.props;
-    const base = useFullData ? fullData : data;
-
-    // we don't want to include analysis transforms when we're in the create panel
-    const filteredTracesFullDataPositions = [];
-    const filteredTraces = base.filter((t, i) => {
-      if (excludeFits) {
-        return !(t.transforms && t.transforms.every(tr => tr.type === 'fit'));
-      }
-      filteredTracesFullDataPositions.push(i);
-      return true;
-    });
-
-    const groupedTraces = filteredTraces.reduce(
-      (allTraces, nextTrace, index) => {
-        const traceType = plotlyTraceToCustomTrace(nextTrace);
-        const adjustedIndex = useFullData ? nextTrace.index : index;
-        if (!allTraces[traceType]) {
-          allTraces[traceType] = [];
-        }
-        allTraces[traceType].push(adjustedIndex);
-        return allTraces;
-      },
-      {}
-    );
-
     if (canAdd) {
-      return this.renderCanAddPanel(
-        filteredTraces,
-        filteredTracesFullDataPositions
-      );
-    }
+      const addAction = {
+        label: _('Trace'),
+        handler: ({onUpdate}) => {
+          if (onUpdate) {
+            onUpdate({
+              type: EDITOR_ACTIONS.ADD_TRACE,
+            });
+          }
+        },
+      };
 
-    if (
-      canGroup &&
-      filteredTraces.length > 1 &&
-      Object.keys(groupedTraces).length > 0
-    ) {
       return (
-        <TraceRequiredPanel noPadding>
-          <Tabs>
-            <TabList>
-              <Tab>{_('Individually')}</Tab>
-              <Tab>{_('By Type')}</Tab>
-            </TabList>
-            <TabPanel>
-              <PlotlyPanel>
-                {filteredTraces.length
-                  ? this.renderIndividualTraceFolds(
-                      filteredTraces,
-                      filteredTracesFullDataPositions
-                    )
-                  : null}
-              </PlotlyPanel>
-            </TabPanel>
-            <TabPanel>
-              <PlotlyPanel>
-                {Object.keys(groupedTraces).length
-                  ? this.renderGroupedTraceFolds(groupedTraces)
-                  : null}
-              </PlotlyPanel>
-            </TabPanel>
-          </Tabs>
-        </TraceRequiredPanel>
+        <PlotlyPanel addAction={addAction}>
+          {this.renderTraceFolds()}
+        </PlotlyPanel>
       );
     }
 
-    return (
-      <TraceRequiredPanel>
-        {filteredTraces.length
-          ? this.renderIndividualTraceFolds(
-              filteredTraces,
-              filteredTracesFullDataPositions
-            )
-          : null}
-      </TraceRequiredPanel>
-    );
+    if (canGroup) {
+      if (this.filteredTraces.length === 1) {
+        return (
+          <TraceRequiredPanel>
+            <PlotlyPanel>{this.renderUngroupedTraceFolds()}</PlotlyPanel>
+          </TraceRequiredPanel>
+        );
+      }
+
+      if (this.filteredTraces.length > 1) {
+        return (
+          <TraceRequiredPanel noPadding>
+            <Tabs>
+              <TabList>
+                <Tab>{_('Individually')}</Tab>
+                <Tab>{_('By Type')}</Tab>
+              </TabList>
+              <TabPanel>
+                <PlotlyPanel>{this.renderUngroupedTraceFolds()}</PlotlyPanel>
+              </TabPanel>
+              <TabPanel>
+                <PlotlyPanel>{this.renderGroupedTraceFolds()}</PlotlyPanel>
+              </TabPanel>
+            </Tabs>
+          </TraceRequiredPanel>
+        );
+      }
+    }
+
+    return <TraceRequiredPanel>{this.renderTraceFolds()}</TraceRequiredPanel>;
   }
 }
 
@@ -213,7 +178,6 @@ TraceAccordion.propTypes = {
   children: PropTypes.node,
   excludeFits: PropTypes.bool,
   messageIfEmptyFold: PropTypes.string,
-  useFullData: PropTypes.bool,
 };
 
 export default TraceAccordion;

--- a/src/components/containers/TransformAccordion.js
+++ b/src/components/containers/TransformAccordion.js
@@ -83,9 +83,17 @@ class TransformAccordion extends Component {
         </TransformFold>
       ));
 
+    // cannot have 2 Split transforms on one trace:
+    // https://github.com/plotly/plotly.js/issues/1742
+    const addActionOptions =
+      container.transforms &&
+      container.transforms.some(t => t.type === 'groupby')
+        ? transformTypes.filter(t => t.type !== 'groupby')
+        : transformTypes;
+
     const addAction = {
       label: _('Transform'),
-      handler: transformTypes.map(({label, type}) => {
+      handler: addActionOptions.map(({label, type}) => {
         return {
           label,
           handler: context => {

--- a/src/components/containers/TransformAccordion.js
+++ b/src/components/containers/TransformAccordion.js
@@ -104,6 +104,10 @@ class TransformAccordion extends Component {
                 payload.groups = null;
               }
 
+              if (type === 'groupby') {
+                payload.styles = [];
+              }
+
               updateContainer({[key]: payload});
             }
           },

--- a/src/components/fields/DataSelector.js
+++ b/src/components/fields/DataSelector.js
@@ -87,10 +87,34 @@ export class UnconnectedDataSelector extends Component {
     if (
       this.props.container.type &&
       this.props.container.type === 'groupby' &&
+      this.props.container.styles &&
+      !this.props.container.styles.length &&
       data
     ) {
-      const styles = data.map(groupEl => ({target: groupEl, value: {}}));
+      const dedupedGroups = [];
+      data.forEach(group => {
+        if (!dedupedGroups.includes(group)) {
+          dedupedGroups.push(group);
+        }
+      });
+
+      const styles = dedupedGroups.map(groupEl => ({
+        target: groupEl,
+        value: {},
+      }));
+
       update.styles = styles;
+    }
+
+    // When clearing the data selector of groupby transforms, we want to clear
+    // all the styles we've added
+    if (
+      this.props.container.type &&
+      this.props.container.type === 'groupby' &&
+      this.props.container.styles.length &&
+      value === null
+    ) {
+      update.styles = [];
     }
 
     this.props.updateContainer(update);
@@ -146,6 +170,7 @@ UnconnectedDataSelector.contextTypes = {
     toSrc: PropTypes.func.isRequired,
     fromSrc: PropTypes.func.isRequired,
   }),
+  container: PropTypes.object,
 };
 
 function modifyPlotProps(props, context, plotProps) {

--- a/src/components/fields/DataSelector.js
+++ b/src/components/fields/DataSelector.js
@@ -84,39 +84,6 @@ export class UnconnectedDataSelector extends Component {
       }
     );
 
-    if (
-      this.props.container.type &&
-      this.props.container.type === 'groupby' &&
-      this.props.container.styles &&
-      !this.props.container.styles.length &&
-      data
-    ) {
-      const dedupedGroups = [];
-      data.forEach(group => {
-        if (!dedupedGroups.includes(group)) {
-          dedupedGroups.push(group);
-        }
-      });
-
-      const styles = dedupedGroups.map(groupEl => ({
-        target: groupEl,
-        value: {},
-      }));
-
-      update.styles = styles;
-    }
-
-    // When clearing the data selector of groupby transforms, we want to clear
-    // all the styles we've added
-    if (
-      this.props.container.type &&
-      this.props.container.type === 'groupby' &&
-      this.props.container.styles.length &&
-      value === null
-    ) {
-      update.styles = [];
-    }
-
     this.props.updateContainer(update);
   }
 

--- a/src/components/fields/DataSelector.js
+++ b/src/components/fields/DataSelector.js
@@ -49,7 +49,7 @@ export class UnconnectedDataSelector extends Component {
         Array.isArray(this.fullValue);
     }
 
-    this.hasData = props.attr in props.container;
+    this.hasData = props.container ? props.attr in props.container : false;
   }
 
   updatePlot(value) {

--- a/src/components/fields/DataSelector.js
+++ b/src/components/fields/DataSelector.js
@@ -83,6 +83,16 @@ export class UnconnectedDataSelector extends Component {
           : null,
       }
     );
+
+    if (
+      this.props.container.type &&
+      this.props.container.type === 'groupby' &&
+      data
+    ) {
+      const styles = data.map(groupEl => ({target: groupEl, value: {}}));
+      update.styles = styles;
+    }
+
     this.props.updateContainer(update);
   }
 

--- a/src/components/fields/MarkerColor.js
+++ b/src/components/fields/MarkerColor.js
@@ -156,72 +156,87 @@ class UnconnectedMarkerColor extends Component {
 
   render() {
     const {attr} = this.props;
-    const {localize: _} = this.context;
-    const {type} = this.state;
-    const options = [
-      {label: _('Constant'), value: 'constant'},
-      {label: _('Variable'), value: 'variable'},
-    ];
+    const {localize: _, container} = this.context;
+
+    // TO DO: https://github.com/plotly/react-chart-editor/issues/654
+    const noSplitsPresent =
+      container &&
+      (!container.transforms ||
+        !container.transforms.filter(t => t.type === 'groupby').length);
+
+    if (noSplitsPresent) {
+      const {type} = this.state;
+      const options = [
+        {label: _('Constant'), value: 'constant'},
+        {label: _('Variable'), value: 'variable'},
+      ];
+
+      return (
+        <Fragment>
+          <Field {...this.props} attr={attr}>
+            <Field multiValued={this.isMultiValued() && !this.state.type}>
+              <RadioBlocks
+                options={options}
+                activeOption={type}
+                onOptionChange={this.setType}
+              />
+
+              {!type ? null : (
+                <Info>
+                  {type === 'constant'
+                    ? _('All points in a trace are colored in the same color.')
+                    : _('Each point in a trace is colored according to data.')}
+                </Info>
+              )}
+            </Field>
+
+            {!type
+              ? null
+              : type === 'constant'
+                ? this.renderConstantControls()
+                : this.renderVariableControls()}
+          </Field>
+          {type === 'constant' ? null : (
+            <Fragment>
+              <Radio
+                label={_('Colorscale Direction')}
+                attr="marker.reversescale"
+                options={[
+                  {label: _('Normal'), value: false},
+                  {label: _('Reversed'), value: true},
+                ]}
+              />
+              <Radio
+                label={_('Color Bar')}
+                attr="marker.showscale"
+                options={[
+                  {label: _('Show'), value: true},
+                  {label: _('Hide'), value: false},
+                ]}
+              />
+              <VisibilitySelect
+                label={_('Colorscale Range')}
+                attr="marker.cauto"
+                options={[
+                  {label: _('Auto'), value: true},
+                  {label: _('Custom'), value: false},
+                ]}
+                showOn={false}
+                dafault={true}
+              >
+                <Numeric label={_('Min')} attr="marker.cmin" />
+                <Numeric label={_('Max')} attr="marker.cmax" />
+              </VisibilitySelect>
+            </Fragment>
+          )}
+        </Fragment>
+      );
+    }
 
     return (
-      <Fragment>
-        <Field {...this.props} attr={attr}>
-          <Field multiValued={this.isMultiValued() && !this.state.type}>
-            <RadioBlocks
-              options={options}
-              activeOption={type}
-              onOptionChange={this.setType}
-            />
-
-            {!type ? null : (
-              <Info>
-                {type === 'constant'
-                  ? _('All points in a trace are colored in the same color.')
-                  : _('Each point in a trace is colored according to data.')}
-              </Info>
-            )}
-          </Field>
-
-          {!type
-            ? null
-            : type === 'constant'
-              ? this.renderConstantControls()
-              : this.renderVariableControls()}
-        </Field>
-        {type === 'constant' ? null : (
-          <Fragment>
-            <Radio
-              label={_('Colorscale Direction')}
-              attr="marker.reversescale"
-              options={[
-                {label: _('Normal'), value: false},
-                {label: _('Reversed'), value: true},
-              ]}
-            />
-            <Radio
-              label={_('Color Bar')}
-              attr="marker.showscale"
-              options={[
-                {label: _('Show'), value: true},
-                {label: _('Hide'), value: false},
-              ]}
-            />
-            <VisibilitySelect
-              label={_('Colorscale Range')}
-              attr="marker.cauto"
-              options={[
-                {label: _('Auto'), value: true},
-                {label: _('Custom'), value: false},
-              ]}
-              showOn={false}
-              dafault={true}
-            >
-              <Numeric label={_('Min')} attr="marker.cmin" />
-              <Numeric label={_('Max')} attr="marker.cmax" />
-            </VisibilitySelect>
-          </Fragment>
-        )}
-      </Fragment>
+      <Field {...this.props} attr={attr}>
+        {this.renderConstantControls()}
+      </Field>
     );
   }
 }
@@ -236,6 +251,7 @@ UnconnectedMarkerColor.contextTypes = {
   localize: PropTypes.func,
   updateContainer: PropTypes.func,
   traceIndexes: PropTypes.array,
+  container: PropTypes.object,
 };
 
 export default connectToContainer(UnconnectedMarkerColor);

--- a/src/components/fields/MarkerColor.js
+++ b/src/components/fields/MarkerColor.js
@@ -91,8 +91,10 @@ class UnconnectedMarkerColor extends Component {
       (Array.isArray(this.props.fullValue) &&
         this.props.fullValue.includes(MULTI_VALUED)) ||
       (this.props.container.marker &&
+        this.props.container.marker.colorscale &&
         this.props.container.marker.colorscale === MULTI_VALUED) ||
       (this.props.container.marker &&
+        this.props.container.marker.colorsrc &&
         this.props.container.marker.colorsrc === MULTI_VALUED) ||
       (this.props.container.marker &&
         this.props.container.marker.color &&
@@ -130,12 +132,12 @@ class UnconnectedMarkerColor extends Component {
 
   renderVariableControls() {
     const multiValued =
-      (this.props.container &&
-        this.props.container.marker &&
-        (this.props.container.marker.colorscale &&
-          this.props.container.marker.colorscale === MULTI_VALUED)) ||
-      (this.props.container.marker.colorsrc &&
-        this.props.container.marker.colorsrc === MULTI_VALUED);
+      this.props.container &&
+      this.props.container.marker &&
+      ((this.props.container.marker.colorscale &&
+        this.props.container.marker.colorscale === MULTI_VALUED) ||
+        (this.props.container.marker.colorsrc &&
+          this.props.container.marker.colorsrc === MULTI_VALUED));
     return (
       <Field multiValued={multiValued}>
         <DataSelector suppressMultiValuedMessage attr="marker.color" />

--- a/src/default_panels/GraphSubplotsPanel.js
+++ b/src/default_panels/GraphSubplotsPanel.js
@@ -17,7 +17,7 @@ import {
 import {TRACE_TO_AXIS} from '../lib/constants';
 
 const GraphSubplotsPanel = (props, {localize: _}) => (
-  <SubplotAccordion canGroup>
+  <SubplotAccordion>
     <PlotlySection name={_('Boundaries')} attr="xaxis.domain[0]">
       <AxisOverlayDropdown label={_('X Overlay')} attr="xaxis.overlaying" />
       <AxisOverlayDropdown label={_('Y Overlay')} attr="yaxis.overlaying" />

--- a/src/default_panels/StyleTracesPanel.js
+++ b/src/default_panels/StyleTracesPanel.js
@@ -39,7 +39,7 @@ import {
 } from '../components/fields/derived';
 
 const StyleTracesPanel = (props, {localize: _}) => (
-  <TraceAccordion canGroup useFullData>
+  <TraceAccordion canGroup>
     <TextEditor label={_('Name')} attr="name" richTextOnly />
     <ShowInLegend
       label="Show in Legend"

--- a/src/default_panels/StyleTracesPanel.js
+++ b/src/default_panels/StyleTracesPanel.js
@@ -39,7 +39,7 @@ import {
 } from '../components/fields/derived';
 
 const StyleTracesPanel = (props, {localize: _}) => (
-  <TraceAccordion canGroup>
+  <TraceAccordion canGroup useFullData>
     <TextEditor label={_('Name')} attr="name" richTextOnly />
     <ShowInLegend
       label="Show in Legend"

--- a/src/lib/customTraceType.js
+++ b/src/lib/customTraceType.js
@@ -1,6 +1,12 @@
 import {COLORS} from 'lib/constants';
 
 export function plotlyTraceToCustomTrace(trace) {
+  if (typeof trace !== 'object') {
+    throw new Error(
+      `trace provided to plotlyTraceToCustomTrace function should be an object, received ${typeof trace}`
+    );
+  }
+
   const gl = 'gl';
   const type = trace.type
     ? trace.type.endsWith(gl)

--- a/src/lib/multiValues.js
+++ b/src/lib/multiValues.js
@@ -22,7 +22,7 @@ function setMultiValuedContainer(intoObj, fromObj, key, config = {}) {
 
   // don't merge private attrs
   if (
-    (typeof key === 'string' && key.charAt(0) === '_') ||
+    (typeof key === 'string' && key.charAt(0) === '_' && key !== '_group') ||
     typeof intoVal === 'function' ||
     key === 'module'
   ) {

--- a/src/shame.js
+++ b/src/shame.js
@@ -113,7 +113,45 @@ export const shamefullyAddTableColumns = (graphDiv, {traceIndexes, update}) => {
   }
 };
 
-export const shamefullyCreateSplitStyles = (
+export const shamefullyAdjustSplitStyleTargetContainers = (
+  graphDiv,
+  {traceIndexes, update}
+) => {
+  for (const attr in update) {
+    if (attr && attr.startsWith('transforms') && attr.endsWith('groups')) {
+      const transformIndex = parseInt(attr.split('[')[1], 10);
+      const transform =
+        graphDiv.data[traceIndexes[0]].transforms[transformIndex];
+
+      if (transform && transform.type === 'groupby' && transform.styles) {
+        // Create style containers for all groups
+        if (!transform.styles.length && update[attr]) {
+          const dedupedGroups = [];
+          update[attr].forEach(group => {
+            if (!dedupedGroups.includes(group)) {
+              dedupedGroups.push(group);
+            }
+          });
+
+          const styles = dedupedGroups.map(groupEl => ({
+            target: groupEl,
+            value: {},
+          }));
+
+          update[`transforms[${transformIndex}].styles`] = styles;
+        }
+
+        // When clearing the data selector of groupby transforms, we want to clear
+        // all the styles we've added
+        if (transform.styles.length && !update[attr]) {
+          update[`transforms[${transformIndex}].styles`] = [];
+        }
+      }
+    }
+  }
+};
+
+export const shamefullyCreateSplitStyleProps = (
   graphDiv,
   attr,
   traceIndex,

--- a/src/shame.js
+++ b/src/shame.js
@@ -125,7 +125,7 @@ export const shamefullyCreateSplitStyles = (
 
   let indexOfSplitTransform = null;
 
-  graphDiv.data[traceIndex].transforms.filter((t, i) => {
+  graphDiv.data[traceIndex].transforms.forEach((t, i) => {
     if (t.type === 'groupby') {
       indexOfSplitTransform = i;
     }
@@ -134,7 +134,7 @@ export const shamefullyCreateSplitStyles = (
   function getProp(group) {
     let indexOfStyleObject = null;
 
-    graphDiv.data[traceIndex].transforms[indexOfSplitTransform].styles.filter(
+    graphDiv.data[traceIndex].transforms[indexOfSplitTransform].styles.forEach(
       (s, i) => {
         if (s.target.toString() === group) {
           indexOfStyleObject = i;

--- a/src/shame.js
+++ b/src/shame.js
@@ -112,3 +112,55 @@ export const shamefullyAddTableColumns = (graphDiv, {traceIndexes, update}) => {
     update['header.values'] = null;
   }
 };
+
+export const shamefullyCreateSplitStyles = (
+  graphDiv,
+  attr,
+  traceIndex,
+  splitTraceGroup
+) => {
+  if (!Array.isArray(splitTraceGroup)) {
+    splitTraceGroup = [splitTraceGroup]; // eslint-disable-line
+  }
+
+  let indexOfSplitTransform = null;
+
+  graphDiv.data[traceIndex].transforms.filter((t, i) => {
+    if (t.type === 'groupby') {
+      indexOfSplitTransform = i;
+    }
+  });
+
+  function getProp(group) {
+    let indexOfStyleObject = null;
+
+    graphDiv.data[traceIndex].transforms[indexOfSplitTransform].styles.filter(
+      (s, i) => {
+        if (s.target.toString() === group) {
+          indexOfStyleObject = i;
+        }
+      }
+    );
+
+    let path =
+      graphDiv.data[traceIndex].transforms[indexOfSplitTransform].styles[
+        indexOfStyleObject
+      ].value;
+
+    attr.split('.').forEach(p => {
+      if (!path[p]) {
+        path[p] = {};
+      }
+      path = path[p];
+    });
+
+    return nestedProperty(
+      graphDiv.data[traceIndex].transforms[indexOfSplitTransform].styles[
+        indexOfStyleObject
+      ].value,
+      attr
+    );
+  }
+
+  return splitTraceGroup.map(g => getProp(g));
+};


### PR DESCRIPTION
Closes: #528

Here are the changes that were introduced with this pr:
- Folds are created based on the number of traces in fullData if the `useFullData` flag is used on a TraceAccordion: this is done in the StyleTracesPanel

- When the useFullData flag is used, a new prop `fullDataArrayPosition` is passed to the Fold, which indicates the index/indexes in the fullData array, that Fold represents (depending on whether the fold represents a single trace or a group of traces).

- If we're using fullData in the TraceAccordion, the format of `traceIndexes` changes as well, in the case that we have split traces. Because split traces all refer to a single trace in the data array, in the individual style tabs, we will have more than one Fold that will have the same traceIndex. Also in the grouped tab, we could have the same index repeated many times. 
Ex:
grouped scattered traces fold, could have: 
traceIndexes: [0, 0, 0, 1],
fullDataArrayPosition: [0, 1, 2, 3]

- Styling split traces, writes to their data[x].transforms[y].styles[z].value object in the individual panel AND in the grouped trace panel. In the grouped case, it wasn't enough to just write the style to the parent trace because if a style had been already present in the transforms[y].styles[z].value object, then the parent could not override it.