### PR TITLE
rename 'hover projections'

### DIFF
--- a/src/default_panels/StyleAxesPanel.js
+++ b/src/default_panels/StyleAxesPanel.js
@@ -380,7 +380,7 @@ class StyleAxesPanel extends Component {
         </AxesFold>
 
         <AxesFold
-          name={_('Hover Projections')}
+          name={_('Spike Lines')}
           axisFilter={axis =>
             !(
               axis._subplot.includes('ternary') ||


### PR DESCRIPTION
The plotly.js modebar calls them spike lines :)