### PR TITLE
Interpolate scss variable in calc()

### DIFF
--- a/src/styles/components/widgets/_colorpicker.scss
+++ b/src/styles/components/widgets/_colorpicker.scss
@@ -99,7 +99,7 @@ $colorpicker-width: 185px;
 .fold .fold {
   .colorpicker__container {
     width: calc(
-      $colorpicker-width - var(--spacing-half-unit) - var(--spacing-half-unit)
+      #{$colorpicker-width} - var(--spacing-half-unit) - var(--spacing-half-unit)
     );
   }
 }


### PR DESCRIPTION
The CSS still contains $colorpicker-width as Sass variables are not replaced within CSS calcs.

Sass issue: https://github.com/sass/sass/issues/818