### PR TITLE
Colorpicker in 2 fold fix

### DIFF
--- a/src/styles/components/widgets/_colorpicker.scss
+++ b/src/styles/components/widgets/_colorpicker.scss
@@ -98,8 +98,9 @@ $colorpicker-width: 185px;
 
 .fold .fold {
   .colorpicker__container {
-    width: calc(
-      #{$colorpicker-width} - var(--spacing-half-unit) - var(--spacing-half-unit)
-    );
+    width: calc(#{$colorpicker-width} - var(--spacing-half-unit) - var(--spacing-half-unit));
+  }
+  .colorpicker__outer {
+    width: calc(#{$colorpicker-width} - var(--spacing-half-unit) - var(--spacing-half-unit));
   }
 }


### PR DESCRIPTION
Colorpicker in folds within folds (as in Color Bars panel) - ensure that it doesn't resize horizontally when clicked.