### PR TITLE
change colorscale reset value: [] => null (for python api)

### DIFF
--- a/src/components/fields/MarkerColor.js
+++ b/src/components/fields/MarkerColor.js
@@ -58,7 +58,7 @@ class UnconnectedMarkerColor extends Component {
         this.context.updateContainer({
           ['marker.color']: null,
           ['marker.colorsrc']: null,
-          ['marker.colorscale']: [],
+          ['marker.colorscale']: null,
         });
       }
     }

--- a/src/lib/customTraceType.js
+++ b/src/lib/customTraceType.js
@@ -83,13 +83,6 @@ export function traceTypeToPlotlyInitFigure(traceType, gl = '') {
         type: 'scatter3d',
         mode: 'markers',
       };
-    case 'pie':
-      return {
-        marker: {
-          colors: null,
-        },
-        type: 'pie',
-      };
     case 'bar':
       return {
         orientation: 'v',

--- a/src/lib/customTraceType.js
+++ b/src/lib/customTraceType.js
@@ -86,7 +86,7 @@ export function traceTypeToPlotlyInitFigure(traceType, gl = '') {
     case 'pie':
       return {
         marker: {
-          colors: [],
+          colors: null,
         },
         type: 'pie',
       };


### PR DESCRIPTION
closes: #825

I tested this and it does not seem like it breaks anything for us to have the reset value, when colorscale is a variable, to be null instead of empty array.

I tested this in RCE and streambed:
- tested switching marker.color from constant to variable and changing scales, for individual and grouped traces
- tested making pie charts and changing their colors