### PR TITLE
update plotly.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "fast-isnumeric": "^1.1.1",
     "immutability-helper": "^2.7.1",
     "plotly-icons": "1.2.3",
-    "plotly.js": "1.43.1",
+    "plotly.js": "1.43.2",
     "prop-types": "^15.5.10",
     "raf": "^3.4.0",
     "react-color": "^2.13.8",


### PR DESCRIPTION
1.43.2 changelogs https://github.com/plotly/plotly.js/releases/tag/v1.43.2:
- [x] Fix uirevision behavior for gl3d, geo and mapbox subplots [#3394]
- [x] Fix reversescale behavior for surface, mesh3d and streamtube traces (bug introduced in 1.43.0) [#3418]
- [x] Fix modebar hover styling (bug introduced in 1.43.0) [#3397]
- [x] Fix horizontal box / violin hover label misalignment under hovermode:'closest' [#3401]
- [x] Fix ohlc and candlestick hover for traces with empty items [#3366]
- [x] Fix surface trace visible logic [#3365]
- [x] Fix mesh3d trace visible logic [#3369]