### PR TITLE
Rename percy snapshots

### DIFF
--- a/src/__percy__/panels.percy.js
+++ b/src/__percy__/panels.percy.js
@@ -59,7 +59,7 @@ Object.keys(mocks).forEach(m => {
     const panelGroup = words[0];
     const panelName = words.slice(1, -1).join(' ');
 
-    percySnapshot(`${m}_${p}`, {widths: [snapshotWidth]}, () =>
+    percySnapshot(`Panels: ${m}_${p}`, {widths: [snapshotWidth]}, () =>
       panelFixture(panels[p], panelGroup, panelName, mocks[m])
     );
   });


### PR DESCRIPTION
This is a PR to transition to percy storybook - there are no changes except for percy snapshot names.
This is just to make sure that we don't overlook visual changes introduced in https://github.com/plotly/react-chart-editor/pull/853 