### PR TITLE
Reconfigure Renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,33 @@
 {
   "extends": [
     "config:base"
+  ],
+  "packageRules": [
+    {
+      "updateTypes": "minor",
+      "depTypeList": [
+        "dependencies"
+      ],
+      "groupName": "minor deps",
+      "schedule": [
+        "before 2am on monday"
+      ]
+    },
+    {
+      "updateTypes": "minor",
+      "depTypeList": [
+        "devDependencies"
+      ],
+      "groupName": "minor devDeps",
+      "schedule": [
+        "before 2am on monday"
+      ]
+    },
+    {
+      "packageNames": [
+        "plotly.js"
+      ],
+      "groupName": "plotly.js"
+    }
   ]
 }


### PR DESCRIPTION
Group dependency PRs as follows:
- 1 PR per week for all minor bumps of devDeps
- 1 PR per week for all minor bumps of deps
- exclude plotly.js - have PRs generated instantly
- leave default behaviour for major bumps for all - create separate PRs each time