### PR TITLE
Fix some updates

### DIFF
--- a/.storybook/webpack.config.js
+++ b/.storybook/webpack.config.js
@@ -1,14 +1,10 @@
 const path = require('path');
 
-module.exports = {
-  devtool: 'false',
-  module: {
-    rules: [
-      {
-        test: /\.(css|scss)?$/,
-        loaders: ['style-loader', 'css-loader', 'sass-loader'],
-        include: path.resolve(__dirname, '../'),
-      },
-    ],
-  },
+module.exports = async ({config, mode}) => {
+  config.module.rules.push({
+    test: /\.scss$/,
+    use: ['style-loader', 'css-loader', 'sass-loader'],
+    include: path.resolve(__dirname, '../'),
+  });
+  return config;
 };

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "node-sass": "4.12.0",
     "postcss": "7.0.18",
     "postcss-combine-duplicated-selectors": "8.0.2",
-    "postcss-custom-properties": "9.0.2",
+    "postcss-custom-properties": "8.0.11",
     "postcss-remove-root": "0.0.2",
     "prettier": "1.18.2",
     "react": "16.9.0",


### PR DESCRIPTION
Revert postcss-custom-properties update - 9.0.2 doesn't work - https://github.com/plotly/react-chart-editor/pull/940#issuecomment-535157165
Use a different style of storybook webpack config, as the old style is deprecated - https://storybook.js.org/docs/configurations/custom-webpack-config/#webpack-customisation-modes