### PR TITLE
Require Node.js v10 or above

### DIFF
--- a/package.json
+++ b/package.json
@@ -105,6 +105,9 @@
     "react": ">15",
     "react-dom": ">15"
   },
+  "engines": {
+    "node": ">=10.0.0"
+  },
   "homepage": "https://plotly.github.io/react-chart-editor/",
   "jest": {
     "roots": [


### PR DESCRIPTION
Avoid confusion by requiring node v10 or above.
Closes https://github.com/plotly/react-chart-editor/issues/1019